### PR TITLE
🐛 base entity 관련 warning

### DIFF
--- a/src/main/java/knu/team1/be/boost/common/entity/BaseEntity.java
+++ b/src/main/java/knu/team1/be/boost/common/entity/BaseEntity.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 import java.util.UUID;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -33,6 +34,7 @@ public abstract class BaseEntity {
     private LocalDateTime updatedAt;
 
     @Column(name = "deleted", nullable = false)
+    @Builder.Default
     private boolean deleted = false;
 
 }

--- a/src/main/java/knu/team1/be/boost/file/entity/File.java
+++ b/src/main/java/knu/team1/be/boost/file/entity/File.java
@@ -17,6 +17,7 @@ import knu.team1.be.boost.file.entity.vo.StorageKey;
 import knu.team1.be.boost.member.entity.Member;
 import knu.team1.be.boost.task.entity.Task;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -50,6 +51,7 @@ public class File extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
+    @Builder.Default
     private FileStatus status = FileStatus.PENDING;
 
     @Column(name = "completed_at")


### PR DESCRIPTION
## PR
### 🔍 한 줄 요약
- @SuperBuilder 사용시 빌더를 생성할 때 필드 초기화식을 무시하는 문제.
- 위와 같은 이유로 테스트 코드 실행시 warning 메세지가 나오는 문제를 `@Builder.Default`로  해결

### ✨ 작업 내용
- BaseEntity의 deleted 필드와 FileEntity에 status 필드에 `@Builder.Default` 추가
- 해당 어노테이션으로 빌더에서 값이 지정되지 않았을 경우에 초기화식을 적용하도록 수정
- 즉, 빌더로 객체 생성 시에도 기본값이 보장되도록 수정

### #️⃣ 연관 이슈
- Close #12 