### PR TITLE
✨BaseEntity에서 soft delete 필드 분리

### DIFF
--- a/src/main/java/knu/team1/be/boost/common/entity/BaseEntity.java
+++ b/src/main/java/knu/team1/be/boost/common/entity/BaseEntity.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 import java.util.UUID;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -16,7 +17,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 @Getter
 @MappedSuperclass
 @SuperBuilder
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public abstract class BaseEntity {
 
     @Id
@@ -31,8 +32,4 @@ public abstract class BaseEntity {
     @UpdateTimestamp
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
-
-    @Column(name = "deleted", nullable = false)
-    private boolean deleted = false;
-
 }

--- a/src/main/java/knu/team1/be/boost/common/entity/SoftDeletableEntity.java
+++ b/src/main/java/knu/team1/be/boost/common/entity/SoftDeletableEntity.java
@@ -1,0 +1,24 @@
+package knu.team1.be.boost.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@MappedSuperclass
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class SoftDeletableEntity extends BaseEntity {
+
+    @Column(name = "deleted", nullable = false)
+    @Builder.Default
+    private boolean deleted = false;
+
+    @Column(name = "deletedAt")
+    private LocalDateTime deletedAt;
+}

--- a/src/main/java/knu/team1/be/boost/file/entity/File.java
+++ b/src/main/java/knu/team1/be/boost/file/entity/File.java
@@ -10,7 +10,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
-import knu.team1.be.boost.common.entity.BaseEntity;
+import knu.team1.be.boost.common.entity.SoftDeletableEntity;
 import knu.team1.be.boost.file.dto.FileRequest;
 import knu.team1.be.boost.file.entity.vo.FileMetadata;
 import knu.team1.be.boost.file.entity.vo.StorageKey;
@@ -28,7 +28,7 @@ import org.hibernate.annotations.SQLDelete;
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE file SET deleted = true WHERE id = ?")
-public class File extends BaseEntity {
+public class File extends SoftDeletableEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")   // TODO: 인증 붙이면 nullable = false 활성화

--- a/src/main/java/knu/team1/be/boost/member/entity/Member.java
+++ b/src/main/java/knu/team1/be/boost/member/entity/Member.java
@@ -5,7 +5,7 @@ import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
-import knu.team1.be.boost.common.entity.BaseEntity;
+import knu.team1.be.boost.common.entity.SoftDeletableEntity;
 import knu.team1.be.boost.member.vo.OauthInfo;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -26,7 +26,7 @@ import org.hibernate.annotations.SQLRestriction;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE members SET deleted = true WHERE id = ?")
 @SQLRestriction("deleted = false")
-public class Member extends BaseEntity {
+public class Member extends SoftDeletableEntity {
 
     @Embedded
     private OauthInfo oauthInfo;

--- a/src/main/java/knu/team1/be/boost/task/entity/Task.java
+++ b/src/main/java/knu/team1/be/boost/task/entity/Task.java
@@ -5,6 +5,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.util.UUID;
+import knu.team1.be.boost.common.entity.SoftDeletableEntity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,7 +18,7 @@ import org.hibernate.annotations.SQLDelete;
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE task SET deleted = true WHERE id = ?")
-public class Task {
+public class Task extends SoftDeletableEntity {
 
     @Id
     @GeneratedValue


### PR DESCRIPTION
## PR
### 🔍 한 줄 요약
- BaseEntity에서 SoftDeletableEntity로 soft delete 속성 분리

### ✨ 작업 내용
- deleted 필드 SoftDeletableEntity로 이동
- deletedAt 필드 SoftDeletableEntity에 추가
- soft delete가 필요한 엔티티는 SoftDeletableEntity를 상속하도록 변경
- soft delete가 불필요한 엔티티는 BaseEntity만 상속 유지

### #️⃣ 연관 이슈
- Close #13 