### PR TITLE
✨ 파일 Entity @SQLRestriction("deleted = false") 적용

### DIFF
--- a/src/main/java/knu/team1/be/boost/file/entity/File.java
+++ b/src/main/java/knu/team1/be/boost/file/entity/File.java
@@ -22,6 +22,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
@@ -29,6 +30,7 @@ import org.hibernate.annotations.SQLDelete;
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE file SET deleted = true WHERE id = ?")
+@SQLRestriction("deleted = false")
 public class File extends SoftDeletableEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
## PR
### 🔍 한 줄 요약
- 파일 엔티티에 @SQLRestriction("deleted = false") 어노테이션을 적용한다.

### ✨ 작업 내용
- 파일 엔티티에 @SQLRestriction("deleted = false") 적용으로 조회 쿼리 호출 시 소프트 delete 된 값은 조회되지 않도록 한다.

### #️⃣ 연관 이슈
- Close #20 