### PR TITLE
✨ 파일 API 관련 업로드 용량 제한 추가

### DIFF
--- a/src/main/java/knu/team1/be/boost/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/knu/team1/be/boost/common/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import knu.team1.be.boost.file.exception.FileAlreadyUploadCompletedException;
 import knu.team1.be.boost.file.exception.FileNotFoundException;
 import knu.team1.be.boost.file.exception.FileNotReadyException;
+import knu.team1.be.boost.file.exception.FileTooLargeException;
 import knu.team1.be.boost.file.exception.StorageServiceException;
 import knu.team1.be.boost.task.exception.TaskNotFoundException;
 import org.springframework.http.HttpStatus;
@@ -100,6 +101,16 @@ public class GlobalExceptionHandler {
     })
     public ProblemDetail handleAlreadyCompleted(RuntimeException e, HttpServletRequest req) {
         return ErrorResponses.of(HttpStatus.CONFLICT, e.getMessage(), instance(req));
+    }
+
+    // 413: 요청 본문이 서버가 허용하는 한도 초과한 경우
+    @ExceptionHandler(FileTooLargeException.class)
+    public ProblemDetail handleFileTooLarge(FileTooLargeException e, HttpServletRequest req) {
+        return ErrorResponses.of(
+            HttpStatus.PAYLOAD_TOO_LARGE,
+            e.getMessage(),
+            instance(req)
+        );
     }
 
     // 405/415 등: 스펙 위반

--- a/src/main/java/knu/team1/be/boost/file/exception/FileTooLargeException.java
+++ b/src/main/java/knu/team1/be/boost/file/exception/FileTooLargeException.java
@@ -1,0 +1,14 @@
+package knu.team1.be.boost.file.exception;
+
+public class FileTooLargeException extends RuntimeException {
+
+    public FileTooLargeException(long sizeBytes, long maxBytes) {
+        super("파일 크기가 허용된 최대 용량을 초과했습니다. 요청 크기: "
+            + toMB(sizeBytes) + "MB / 최대 허용: " + toMB(maxBytes) + "MB");
+    }
+
+    private static String toMB(long bytes) {
+        double mb = bytes / 1024.0 / 1024.0;
+        return String.format("%.2f", mb);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -38,3 +38,5 @@ boost:
     region: ap-northeast-2
     upload:
       expire-seconds: 900
+  file:
+    max-upload-size: 5MB


### PR DESCRIPTION
## PR
### 🔍 한 줄 요약
- 파일 업로드 시 최대 5MB 용량 제한 검증 로직 추가합니다.

### ✨ 작업 내용
- FileServiceImpl에서 파일 크기 검증
- FileTooLargeException 추가 (413 Payload Too Large)
- GlobalExceptionHandler에 FileTooLargeException 매핑
- application.yaml에 boost.file.max-upload-size 설정

### #️⃣ 연관 이슈
- Close #15 