### PR TITLE
♻️ Swagger 문서화 관련 컨트롤러 인터페이스 분리

### DIFF
--- a/src/main/java/knu/team1/be/boost/file/controller/FileApi.java
+++ b/src/main/java/knu/team1/be/boost/file/controller/FileApi.java
@@ -1,0 +1,84 @@
+package knu.team1.be.boost.file.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import knu.team1.be.boost.file.dto.FileCompleteRequest;
+import knu.team1.be.boost.file.dto.FileCompleteResponse;
+import knu.team1.be.boost.file.dto.FileRequest;
+import knu.team1.be.boost.file.dto.FileResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Tag(name = "Files", description = "파일 관련 API")
+@RequestMapping("/api/files")
+public interface FileApi {
+
+    @Operation(
+        summary = "파일 메타 생성 + 업로드 Presigned URL 발급",
+        description = "files 테이블에 메타 정보를 생성하고, 업로드 가능한 S3 Presigned URL을 반환합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "201",
+            description = "파일 메타 생성 및 업로드 URL 발급 성공",
+            content = @Content(schema = @Schema(implementation = FileResponse.class))
+        ),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content),
+        @ApiResponse(responseCode = "413", description = "파일 크기 한도 초과", content = @Content),
+        @ApiResponse(responseCode = "500", description = "S3 오류", content = @Content),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
+    })
+    @PostMapping("/upload-url")
+    ResponseEntity<FileResponse> uploadFile(@Valid @RequestBody FileRequest request);
+
+    @Operation(
+        summary = "다운로드 Presigned URL 발급",
+        description = "파일 ID를 기반으로 다운로드 가능한 S3 Presigned URL을 반환합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "다운로드 URL 발급 성공",
+            content = @Content(schema = @Schema(implementation = FileResponse.class))
+        ),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content),
+        @ApiResponse(responseCode = "404", description = "파일을 찾을 수 없음", content = @Content),
+        @ApiResponse(responseCode = "409", description = "업로드 미완료 상태(다운로드 불가)", content = @Content),
+        @ApiResponse(responseCode = "500", description = "S3 오류", content = @Content),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
+    })
+    @GetMapping("/{fileId}/download-url")
+    ResponseEntity<FileResponse> downloadFile(@PathVariable UUID fileId);
+
+    @Operation(
+        summary = "업로드 완료 콜백",
+        description = "파일 업로드가 완료되었음을 서버에 알리고 상태를 COMPLETED로 갱신합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "업로드 완료 처리 성공",
+            content = @Content(schema = @Schema(implementation = FileCompleteResponse.class))
+        ),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content),
+        @ApiResponse(responseCode = "404", description = "파일 또는 할 일을 찾을 수 없음", content = @Content),
+        @ApiResponse(responseCode = "409", description = "이미 업로드 완료 처리된 파일", content = @Content),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
+    })
+    @PatchMapping("/{fileId}/complete")
+    ResponseEntity<FileCompleteResponse> completeUpload(
+        @PathVariable UUID fileId,
+        @Valid @RequestBody FileCompleteRequest request
+    );
+}

--- a/src/main/java/knu/team1/be/boost/file/controller/FileController.java
+++ b/src/main/java/knu/team1/be/boost/file/controller/FileController.java
@@ -1,7 +1,5 @@
 package knu.team1.be.boost.file.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.UUID;
@@ -11,18 +9,12 @@ import knu.team1.be.boost.file.dto.FileRequest;
 import knu.team1.be.boost.file.dto.FileResponse;
 import knu.team1.be.boost.file.service.FileService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Files", description = "파일 관련 API")
 @RestController
-@RequestMapping("/api/files")
-public class FileController {
+public class FileController implements FileApi {
 
     private final FileService fileService;
 
@@ -30,46 +22,25 @@ public class FileController {
         this.fileService = fileService;
     }
 
-    @Operation(
-        summary = "파일 메타 생성 + 업로드 Presigned URL 발급",
-        description = "files 테이블에 메타 정보를 생성하고, 업로드 가능한 S3 Presigned URL을 반환합니다."
-    )
-    @PostMapping("/upload-url")
-    public ResponseEntity<FileResponse> uploadFile(
-        @Valid @RequestBody FileRequest request
-    ) {
+    @Override
+    public ResponseEntity<FileResponse> uploadFile(@Valid @RequestBody FileRequest request) {
         FileResponse fileResponse = fileService.uploadFile(request);
         URI location = URI.create("/api/files/" + fileResponse.fileId());
-
-        return ResponseEntity
-            .created(location)
-            .body(fileResponse);
+        return ResponseEntity.created(location).body(fileResponse);
     }
 
-    @Operation(
-        summary = "다운로드 Presigned URL 발급",
-        description = "파일 ID를 기반으로 다운로드 가능한 S3 Presigned URL을 반환합니다."
-    )
-    @GetMapping("/{fileId}/download-url")
-    public ResponseEntity<FileResponse> downloadFile(
-        @PathVariable UUID fileId
-    ) {
+    @Override
+    public ResponseEntity<FileResponse> downloadFile(@PathVariable UUID fileId) {
         FileResponse fileResponse = fileService.downloadFile(fileId);
-
         return ResponseEntity.ok(fileResponse);
     }
 
-    @Operation(
-        summary = "업로드 완료 콜백",
-        description = "파일 업로드가 완료되었음을 서버에 알리고 상태를 COMPLETED로 갱신합니다."
-    )
-    @PatchMapping("/{fileId}/complete")
+    @Override
     public ResponseEntity<FileCompleteResponse> completeUpload(
         @PathVariable UUID fileId,
         @Valid @RequestBody FileCompleteRequest request
     ) {
         FileCompleteResponse response = fileService.completeUpload(fileId, request);
-
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/knu/team1/be/boost/member/controller/MemberApi.java
+++ b/src/main/java/knu/team1/be/boost/member/controller/MemberApi.java
@@ -1,0 +1,69 @@
+package knu.team1.be.boost.member.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import knu.team1.be.boost.member.dto.MemberResponseDto;
+import knu.team1.be.boost.member.dto.MemberUpdateRequestDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Tag(name = "Members", description = "Member 관련 API")
+@RequestMapping("/api/members")
+public interface MemberApi {
+
+    @Operation(
+        summary = "내 정보 조회",
+        description = "로그인한 회원의 정보를 조회합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "회원 정보 조회 성공",
+            content = @Content(schema = @Schema(implementation = MemberResponseDto.class))
+        ),
+        @ApiResponse(responseCode = "404", description = "회원을 찾을 수 없음", content = @Content),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
+    })
+    @GetMapping("/me")
+    ResponseEntity<MemberResponseDto> getMyInfo();
+
+    @Operation(
+        summary = "내 정보 수정",
+        description = "로그인한 회원의 이름 또는 프로필 이모지를 수정합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "회원 정보 수정 성공",
+            content = @Content(schema = @Schema(implementation = MemberResponseDto.class))
+        ),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content),
+        @ApiResponse(responseCode = "404", description = "회원을 찾을 수 없음", content = @Content),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
+    })
+    @PatchMapping("/me")
+    ResponseEntity<MemberResponseDto> updateMyInfo(
+        @Valid @RequestBody MemberUpdateRequestDto requestDto
+    );
+
+    @Operation(
+        summary = "회원 탈퇴",
+        description = "로그인한 회원의 계정을 탈퇴(soft delete) 처리합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "204", description = "회원 탈퇴 성공", content = @Content),
+        @ApiResponse(responseCode = "404", description = "회원을 찾을 수 없음", content = @Content),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
+    })
+    @DeleteMapping("/me")
+    ResponseEntity<Void> deleteMyAccount();
+}

--- a/src/main/java/knu/team1/be/boost/member/controller/MemberController.java
+++ b/src/main/java/knu/team1/be/boost/member/controller/MemberController.java
@@ -1,10 +1,5 @@
 package knu.team1.be.boost.member.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import knu.team1.be.boost.member.dto.MemberResponseDto;
@@ -12,42 +7,25 @@ import knu.team1.be.boost.member.dto.MemberUpdateRequestDto;
 import knu.team1.be.boost.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/members")
-public class MemberController {
+public class MemberController implements MemberApi {
 
     private final MemberService memberService;
 
     private final UUID memberId = UUID.fromString(
         "a1b2c3d4-e5f6-7890-1234-567890abcdef"); // 테스트용 memberId 임의 생성 -> 로그인 구현시 제거
 
-    @Operation(summary = "내 정보 조회", description = "로그인한 회원의 정보를 조회합니다.")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "조회 성공",
-            content = @Content(schema = @Schema(implementation = MemberResponseDto.class))),
-        @ApiResponse(responseCode = "404", description = "회원을 찾을 수 없음", content = @Content)
-    })
-    @GetMapping("/me")
+    @Override
     public ResponseEntity<MemberResponseDto> getMyInfo() {
         MemberResponseDto memberInfo = memberService.getMember(memberId);
         return ResponseEntity.ok(memberInfo);
     }
 
-    @Operation(summary = "내 정보 수정", description = "로그인한 회원의 이름 또는 프로필 이모지를 수정합니다.")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "수정 성공",
-            content = @Content(schema = @Schema(implementation = MemberResponseDto.class))),
-        @ApiResponse(responseCode = "404", description = "회원을 찾을 수 없음", content = @Content)
-    })
-    @PatchMapping("/me")
+    @Override
     public ResponseEntity<MemberResponseDto> updateMyInfo(
         @Valid @RequestBody MemberUpdateRequestDto requestDto
     ) {
@@ -55,12 +33,7 @@ public class MemberController {
         return ResponseEntity.ok(updatedMemberInfo);
     }
 
-    @Operation(summary = "회원 탈퇴", description = "로그인한 회원의 계정을 탈퇴(soft delete) 처리합니다.")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "204", description = "회원 탈퇴 성공", content = @Content),
-        @ApiResponse(responseCode = "404", description = "회원을 찾을 수 없음", content = @Content)
-    })
-    @DeleteMapping("/me")
+    @Override
     public ResponseEntity<Void> deleteMyAccount() {
         memberService.deleteMember(memberId);
         return ResponseEntity.noContent().build();


### PR DESCRIPTION
## PR
### 🔍 한 줄 요약
- Member Controller와 File Controller를 인터페이스로 분리한다.

### ✨ 작업 내용
- 인터페이스를 추가하여 Swagger 문서 어노테이션을 분리
- Controller는 서비스 호출만 담당하도록 단순화

### #️⃣ 연관 이슈
- Close #21 