### PR TITLE
🐛 @SQLDelete가 deletedAt 필드를 업데이트 하지 않는 버그 수정

### DIFF
--- a/src/main/java/knu/team1/be/boost/common/entity/SoftDeletableEntity.java
+++ b/src/main/java/knu/team1/be/boost/common/entity/SoftDeletableEntity.java
@@ -19,7 +19,7 @@ public abstract class SoftDeletableEntity extends BaseEntity {
     @Builder.Default
     private boolean deleted = false;
 
-    @Column(name = "deletedAt")
+    @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
     public void reactivate() {

--- a/src/main/java/knu/team1/be/boost/file/entity/File.java
+++ b/src/main/java/knu/team1/be/boost/file/entity/File.java
@@ -29,7 +29,7 @@ import org.hibernate.annotations.SQLRestriction;
 @Table(name = "files")
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE files SET deleted = true WHERE id = ?")
+@SQLDelete(sql = "UPDATE files SET deleted = true, deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 @SQLRestriction("deleted = false")
 public class File extends SoftDeletableEntity {
 

--- a/src/main/java/knu/team1/be/boost/member/entity/Member.java
+++ b/src/main/java/knu/team1/be/boost/member/entity/Member.java
@@ -30,7 +30,7 @@ import org.hibernate.annotations.SQLRestriction;
     )
 })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE members SET deleted = true WHERE id = ?")
+@SQLDelete(sql = "UPDATE members SET deleted = true, deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 @SQLRestriction("deleted = false")
 public class Member extends SoftDeletableEntity {
 

--- a/src/main/java/knu/team1/be/boost/project/entity/Project.java
+++ b/src/main/java/knu/team1/be/boost/project/entity/Project.java
@@ -21,7 +21,7 @@ import org.hibernate.annotations.SQLRestriction;
 @Getter
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE projects SET deleted = true, deletedAt = CURRENT_TIMESTAMP WHERE id = ?")
+@SQLDelete(sql = "UPDATE projects SET deleted = true, deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 @SQLRestriction("deleted = false")
 @Table(name = "projects")
 public class Project extends SoftDeletableEntity {

--- a/src/main/java/knu/team1/be/boost/project/entity/Project.java
+++ b/src/main/java/knu/team1/be/boost/project/entity/Project.java
@@ -21,7 +21,7 @@ import org.hibernate.annotations.SQLRestriction;
 @Getter
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE project SET deleted = true, deletedAt = CURRENT_TIMESTAMP WHERE id = ?")
+@SQLDelete(sql = "UPDATE projects SET deleted = true, deletedAt = CURRENT_TIMESTAMP WHERE id = ?")
 @SQLRestriction("deleted = false")
 @Table(name = "projects")
 public class Project extends SoftDeletableEntity {

--- a/src/main/java/knu/team1/be/boost/project/entity/Project.java
+++ b/src/main/java/knu/team1/be/boost/project/entity/Project.java
@@ -21,7 +21,7 @@ import org.hibernate.annotations.SQLRestriction;
 @Getter
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE project SET deleted = true WHERE id = ?")
+@SQLDelete(sql = "UPDATE project SET deleted = true, deletedAt = CURRENT_TIMESTAMP WHERE id = ?")
 @SQLRestriction("deleted = false")
 @Table(name = "projects")
 public class Project extends SoftDeletableEntity {

--- a/src/main/java/knu/team1/be/boost/projectMember/entity/ProjectMember.java
+++ b/src/main/java/knu/team1/be/boost/projectMember/entity/ProjectMember.java
@@ -23,7 +23,7 @@ import org.hibernate.annotations.SQLRestriction;
 @Getter
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE project_member SET deleted = true WHERE id = ?")
+@SQLDelete(sql = "UPDATE project_member SET deleted = true, deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 @SQLRestriction("deleted = false")
 @Table(name = "project_member", uniqueConstraints = {
     @UniqueConstraint(
@@ -46,8 +46,7 @@ public class ProjectMember extends SoftDeletableEntity {
     private ProjectRole role;
 
     /**
-     * 프로젝트와 멤버 간의 연관관계를 나타내는 ProjectMember 엔티티를 생성합니다.
-     * 생성된 엔티티는 프로젝트와 멤버의 컬렉션에 자동으로 추가됩니다.
+     * 프로젝트와 멤버 간의 연관관계를 나타내는 ProjectMember 엔티티를 생성합니다. 생성된 엔티티는 프로젝트와 멤버의 컬렉션에 자동으로 추가됩니다.
      *
      * @param project 연관 지을 프로젝트
      * @param member  연관 지을 멤버

--- a/src/main/java/knu/team1/be/boost/task/entity/Task.java
+++ b/src/main/java/knu/team1/be/boost/task/entity/Task.java
@@ -17,7 +17,7 @@ import org.hibernate.annotations.SQLDelete;
 @Table(name = "task")
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE task SET deleted = true WHERE id = ?")
+@SQLDelete(sql = "UPDATE task SET deleted = true, deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 public class Task extends SoftDeletableEntity {
 
     @Id


### PR DESCRIPTION
## PR
### 🔍 한 줄 요약
- @SQLDelete 어노테이션 내 쿼리 변경

### ✨ 작업 내용
```java
@SQLDelete(sql = "UPDATE project SET deleted = true WHERE id = ?")
```
현재, 엔티티에 위와 같은 어노테이션이 붙어있음.
이는 delete JPA 메서드 호출 시 어노테이션 파라미터 쿼리가 실행되도록하는 어노테이션임.
따라서 delete 메서드가 호출되면 튜플이 삭제되지 않고 deleted 필드만 true로 변하게 됨.

하지만, deletedAt 필드를 업데이트 하지 않고 있음.
따라서 해당 어노테이션을 사용하는 모든 엔티티를 다음과 같은 형태로 수정하였음.
```java
@SQLDelete(sql = "UPDATE project SET deleted = true, deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
```

추가) sql 쿼리 내 project -> projects typo 수정함.

### #️⃣ 연관 이슈
- Close #46