### PR TITLE
✨ 카카오 로그인 API 테스트 코드 작성

### DIFF
--- a/src/main/java/knu/team1/be/boost/auth/controller/AuthApi.java
+++ b/src/main/java/knu/team1/be/boost/auth/controller/AuthApi.java
@@ -8,14 +8,15 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import knu.team1.be.boost.auth.dto.AccessTokenResponseDto;
+import knu.team1.be.boost.auth.dto.LoginRequestDto;
 import knu.team1.be.boost.auth.dto.UserPrincipalDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Auth", description = "로그인 관련 API")
 @RequestMapping("/api/auth")
@@ -35,7 +36,7 @@ public interface AuthApi {
         @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
     })
     @PostMapping("/login/kakao")
-    ResponseEntity<AccessTokenResponseDto> kakaoLogin(@RequestParam("code") String code);
+    ResponseEntity<AccessTokenResponseDto> kakaoLogin(@RequestBody LoginRequestDto requestDto);
 
     @Operation(
         summary = "로그아웃",

--- a/src/main/java/knu/team1/be/boost/auth/controller/AuthController.java
+++ b/src/main/java/knu/team1/be/boost/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package knu.team1.be.boost.auth.controller;
 
 import java.time.Duration;
 import knu.team1.be.boost.auth.dto.AccessTokenResponseDto;
+import knu.team1.be.boost.auth.dto.LoginRequestDto;
 import knu.team1.be.boost.auth.dto.TokenDto;
 import knu.team1.be.boost.auth.dto.UserPrincipalDto;
 import knu.team1.be.boost.auth.service.AuthService;
@@ -13,8 +14,8 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -29,8 +30,10 @@ public class AuthController implements AuthApi {
     private Duration refreshTokenExpireTime;
 
     @Override
-    public ResponseEntity<AccessTokenResponseDto> kakaoLogin(@RequestParam("code") String code) {
-        TokenDto tokenDto = authService.login(code);
+    public ResponseEntity<AccessTokenResponseDto> kakaoLogin(
+        @RequestBody LoginRequestDto requestDto
+    ) {
+        TokenDto tokenDto = authService.login(requestDto.code());
 
         // 헤더에 Refresh Token 쿠키 추가
         HttpHeaders headers = createCookieHeaders(tokenDto.refreshToken());

--- a/src/main/java/knu/team1/be/boost/auth/dto/LoginRequestDto.java
+++ b/src/main/java/knu/team1/be/boost/auth/dto/LoginRequestDto.java
@@ -1,0 +1,5 @@
+package knu.team1.be.boost.auth.dto;
+
+public record LoginRequestDto(String code) {
+
+}

--- a/src/main/java/knu/team1/be/boost/auth/dto/TokenDto.java
+++ b/src/main/java/knu/team1/be/boost/auth/dto/TokenDto.java
@@ -1,11 +1,11 @@
 package knu.team1.be.boost.auth.dto;
 
-import lombok.Builder;
-
-@Builder
 public record TokenDto(
     String accessToken,
     String refreshToken
 ) {
 
+    public static TokenDto of(String accessToken, String refreshToken) {
+        return new TokenDto(accessToken, refreshToken);
+    }
 }

--- a/src/main/java/knu/team1/be/boost/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/knu/team1/be/boost/common/exception/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestCookieException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -146,6 +147,22 @@ public class GlobalExceptionHandler {
         );
     }
 
+    // 400: 필수 요청 헤더가 누락된 경우
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    public ProblemDetail handleMissingRequestHeader(
+        MissingRequestCookieException e,
+        HttpServletRequest req
+    ) {
+        String message = String.format("필수 헤더 '%s'가 누락되었습니다.", e.getHeaders());
+
+        log.warn("[400 BAD_REQUEST] Missing header: {}", e.toString(), e);
+
+        return ErrorResponses.of(
+            HttpStatus.BAD_REQUEST,
+            message,
+            instance(req)
+        );
+    }
 
     // 401: 컨트롤러/서비스 단에서 발생하는 JWT 관련 예외 처리
     // (주로 토큰 재발급 시 만료된 토큰을 파싱하려 할 때 발생)
@@ -159,7 +176,6 @@ public class GlobalExceptionHandler {
             instance(req)
         );
     }
-
 
     // 405/415 등: 스펙 위반
     @ExceptionHandler({

--- a/src/main/java/knu/team1/be/boost/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/knu/team1/be/boost/common/exception/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -120,6 +121,23 @@ public class GlobalExceptionHandler {
         String message = String.format("필수 파라미터 '%s'가 누락되었습니다.", e.getParameterName());
 
         log.warn("[400 BAD_REQUEST] Missing parameter: {}", e.toString(), e);
+
+        return ErrorResponses.of(
+            HttpStatus.BAD_REQUEST,
+            message,
+            instance(req)
+        );
+    }
+
+    // 400: 필수 요청 쿠키가 누락된 경우
+    @ExceptionHandler(MissingRequestCookieException.class)
+    public ProblemDetail handleMissingRequestCookie(
+        MissingRequestCookieException e,
+        HttpServletRequest req
+    ) {
+        String message = String.format("필수 쿠키 '%s'가 누락되었습니다.", e.getCookieName());
+
+        log.warn("[400 BAD_REQUEST] Missing cookie: {}", e.toString(), e);
 
         return ErrorResponses.of(
             HttpStatus.BAD_REQUEST,

--- a/src/main/java/knu/team1/be/boost/security/util/JwtUtil.java
+++ b/src/main/java/knu/team1/be/boost/security/util/JwtUtil.java
@@ -74,10 +74,7 @@ public class JwtUtil {
             .signWith(key, SignatureAlgorithm.HS256)
             .compact();
 
-        return TokenDto.builder()
-            .accessToken(accessToken)
-            .refreshToken(refreshToken)
-            .build();
+        return TokenDto.of(accessToken, refreshToken);
     }
 
     public Authentication getAuthentication(String accessToken) {

--- a/src/test/java/knu/team1/be/boost/auth/controller/AuthControllerTest.java
+++ b/src/test/java/knu/team1/be/boost/auth/controller/AuthControllerTest.java
@@ -1,0 +1,240 @@
+package knu.team1.be.boost.auth.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import jakarta.servlet.http.Cookie;
+import java.util.List;
+import java.util.UUID;
+import knu.team1.be.boost.auth.dto.TokenDto;
+import knu.team1.be.boost.auth.dto.UserPrincipalDto;
+import knu.team1.be.boost.auth.service.AuthService;
+import knu.team1.be.boost.common.exception.BusinessException;
+import knu.team1.be.boost.common.exception.ErrorCode;
+import knu.team1.be.boost.security.util.JwtUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(AuthController.class)
+@AutoConfigureMockMvc(addFilters = true)
+@Import(TestSecurityConfig.class)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AuthService authService;
+
+    @MockitoBean
+    private JwtUtil jwtUtil;
+
+    private Authentication testAuthentication;
+
+    @BeforeEach
+    void setUp() {
+        UserPrincipalDto principal = new UserPrincipalDto(
+            UUID.fromString("123e4567-e89b-12d3-a456-426614174000"),
+            "testUser",
+            "1111"
+        );
+        List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("USER"));
+        this.testAuthentication = new UsernamePasswordAuthenticationToken(
+            principal,
+            null,
+            authorities
+        );
+    }
+
+
+    @Nested
+    @DisplayName("카카오 로그인 API")
+    class KakaoLogin {
+
+        @Test
+        @DisplayName("성공")
+        void kakaoLogin_Success() throws Exception {
+            // given
+            String code = "test_kakao_auth_code";
+            TokenDto tokenDto = new TokenDto("mock_access_token", "mock_refresh_token");
+            given(authService.login(eq(code))).willReturn(tokenDto);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(post("/api/auth/login/kakao")
+                .param("code", code));
+
+            // then
+            resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").value(tokenDto.accessToken()))
+                .andExpect(cookie().exists("refreshToken"));
+        }
+
+        @Test
+        @DisplayName("실패: 인가 코드가 없을 경우 MissingServletRequestParameterException")
+        void kakaoLogin_Fail_WhenCodeIsMissing() throws Exception {
+            // when
+            ResultActions resultActions = mockMvc.perform(post("/api/auth/login/kakao"));
+            // then
+            resultActions.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("실패: 유효하지 않은 인가 코드일 경우 KAKAO_INVALID_AUTH_CODE")
+        void kakaoLogin_Fail_WhenServiceThrowsBusinessException() throws Exception {
+            // given
+            String invalidCode = "invalid_kakao_code";
+            given(authService.login(eq(invalidCode)))
+                .willThrow(new BusinessException(ErrorCode.KAKAO_INVALID_AUTH_CODE));
+
+            // when
+            ResultActions resultActions = mockMvc.perform(post("/api/auth/login/kakao")
+                .param("code", invalidCode));
+
+            // then
+            resultActions.andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("로그아웃 API")
+    class Logout {
+
+        @Test
+        @DisplayName("성공")
+        void logout_Success() throws Exception {
+            // given
+            doNothing().when(authService).logout(any(UserPrincipalDto.class));
+
+            // when
+            ResultActions resultActions = mockMvc.perform(post("/api/auth/logout")
+                .with(authentication(testAuthentication)));
+
+            // then
+            resultActions
+                .andExpect(status().isNoContent())
+                .andExpect(cookie().maxAge("refreshToken", 0));
+        }
+
+        @Test
+        @DisplayName("실패: 인증되지 않은 사용자의 요청일 경우 AUTHENTICATION_FAILED")
+        void logout_Fail_WhenNotAuthenticated() throws Exception {
+            // when
+            ResultActions resultActions = mockMvc.perform(post("/api/auth/logout"));
+            // then
+            resultActions.andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 재발급 API")
+    class Reissue {
+
+        @Test
+        @DisplayName("성공")
+        void reissue_Success() throws Exception {
+            // given
+            String expiredAccessToken = "expired_access_token";
+            String validRefreshToken = "valid_refresh_token";
+            TokenDto newTokenDto = new TokenDto("new_access_token", "new_refresh_token");
+
+            given(jwtUtil.resolveToken("Bearer " + expiredAccessToken))
+                .willReturn(expiredAccessToken);
+            given(authService.reissue(expiredAccessToken, validRefreshToken))
+                .willReturn(newTokenDto);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(post("/api/auth/reissue")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + expiredAccessToken)
+                .cookie(new Cookie("refreshToken", validRefreshToken)));
+
+            // then
+            resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").value(newTokenDto.accessToken()))
+                .andExpect(cookie().value("refreshToken", newTokenDto.refreshToken()));
+        }
+
+        @Test
+        @DisplayName("실패: Refresh Token 쿠키가 없을 경우 MissingRequestCookieException")
+        void reissue_Fail_WhenCookieIsMissing() throws Exception {
+            // when
+            ResultActions resultActions = mockMvc.perform(post("/api/auth/reissue")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer expired_token"));
+            // then
+            resultActions.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("실패: Authorization 헤더가 없을 경우 MissingRequestHeaderException")
+        void reissue_Fail_WhenHeaderIsMissing() throws Exception {
+            // when
+            ResultActions resultActions = mockMvc.perform(post("/api/auth/reissue")
+                .cookie(new Cookie("refreshToken", "valid_token")));
+            // then
+            resultActions.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("실패: 유효하지 않은 Refresh Token일 경우 INVALID_REFRESH_TOKEN")
+        void reissue_Fail_WhenRefreshTokenIsInvalid() throws Exception {
+            // given
+            String expiredAccessToken = "expired_token";
+            String invalidRefreshToken = "invalid_token";
+            given(jwtUtil.resolveToken("Bearer " + expiredAccessToken))
+                .willReturn(expiredAccessToken);
+            given(authService.reissue(expiredAccessToken, invalidRefreshToken))
+                .willThrow(new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN));
+
+            // when
+            ResultActions resultActions = mockMvc.perform(post("/api/auth/reissue")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + expiredAccessToken)
+                .cookie(new Cookie("refreshToken", invalidRefreshToken)));
+
+            // then
+            resultActions.andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("실패: DB에 Refresh Token이 없을 경우 REFRESH_TOKEN_NOT_FOUND")
+        void reissue_Fail_WhenRefreshTokenNotFound() throws Exception {
+            // given
+            String expiredAccessToken = "expired_token";
+            String unknownRefreshToken = "unknown_token";
+            given(jwtUtil.resolveToken("Bearer " + expiredAccessToken))
+                .willReturn(expiredAccessToken);
+            given(authService.reissue(expiredAccessToken, unknownRefreshToken))
+                .willThrow(new BusinessException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
+
+            // when
+            ResultActions resultActions = mockMvc.perform(post("/api/auth/reissue")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + expiredAccessToken)
+                .cookie(new Cookie("refreshToken", unknownRefreshToken)));
+
+            // then
+            resultActions.andExpect(status().isNotFound());
+        }
+    }
+}
+

--- a/src/test/java/knu/team1/be/boost/auth/controller/TestSecurityConfig.java
+++ b/src/test/java/knu/team1/be/boost/auth/controller/TestSecurityConfig.java
@@ -1,0 +1,36 @@
+package knu.team1.be.boost.auth.controller;
+
+import knu.team1.be.boost.security.handler.CustomAuthenticationEntryPoint;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@TestConfiguration
+@EnableWebSecurity
+public class TestSecurityConfig {
+
+    @Bean
+    public CustomAuthenticationEntryPoint customAuthenticationEntryPoint() {
+        return new CustomAuthenticationEntryPoint();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(authz -> authz
+                .requestMatchers(
+                    "/api/auth/login/kakao",
+                    "/api/auth/reissue"
+                ).permitAll()
+                .anyRequest().authenticated()
+            )
+            .exceptionHandling(e -> e
+                .authenticationEntryPoint(customAuthenticationEntryPoint())
+            );
+        return http.build();
+    }
+}
+

--- a/src/test/java/knu/team1/be/boost/auth/service/AuthServiceTest.java
+++ b/src/test/java/knu/team1/be/boost/auth/service/AuthServiceTest.java
@@ -1,0 +1,284 @@
+package knu.team1.be.boost.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import io.jsonwebtoken.JwtException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import knu.team1.be.boost.auth.dto.KakaoDto;
+import knu.team1.be.boost.auth.dto.TokenDto;
+import knu.team1.be.boost.auth.dto.UserPrincipalDto;
+import knu.team1.be.boost.auth.entity.RefreshToken;
+import knu.team1.be.boost.auth.repository.RefreshTokenRepository;
+import knu.team1.be.boost.common.exception.BusinessException;
+import knu.team1.be.boost.common.exception.ErrorCode;
+import knu.team1.be.boost.member.entity.Member;
+import knu.team1.be.boost.member.entity.vo.OauthInfo;
+import knu.team1.be.boost.member.repository.MemberRepository;
+import knu.team1.be.boost.security.util.JwtUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @Mock
+    private KakaoClientService kakaoClientService;
+
+    private final String DEFAULT_AVATAR = "1111";
+
+    @Nested
+    @DisplayName("로그인/회원가입")
+    class Login {
+
+        @Test
+        @DisplayName("성공: 신규 사용자일 경우 회원가입 후 토큰 발급")
+        void login_Success_WhenNewUser() {
+            // given
+            String code = "test_code";
+            KakaoDto.UserInfo mockKakaoUser = createMockKakaoUser(12345L, "라이언");
+            Member newMember = createMockMember(
+                UUID.randomUUID(),
+                mockKakaoUser.id(),
+                mockKakaoUser.kakaoAccount()
+                    .profile()
+                    .nickname()
+            );
+            TokenDto mockTokenDto = new TokenDto("access", "refresh");
+
+            given(kakaoClientService.getUserInfo(code)).willReturn(mockKakaoUser);
+            given(memberRepository.findByOauthInfoProviderAndOauthInfoProviderId("kakao",
+                mockKakaoUser.id())).willReturn(Optional.empty());
+            given(memberRepository.save(any(Member.class))).willReturn(newMember);
+            given(jwtUtil.generateToken(any(Authentication.class))).willReturn(mockTokenDto);
+
+            // when
+            TokenDto resultTokenDto = authService.login(code);
+
+            // then
+            assertThat(resultTokenDto).isEqualTo(mockTokenDto);
+            verify(memberRepository).save(any(Member.class));
+            verify(refreshTokenRepository).save(any(RefreshToken.class));
+        }
+
+        @Test
+        @DisplayName("성공: 기존 사용자일 경우 로그인 후 토큰 발급")
+        void login_Success_WhenExistingUser() {
+            // given
+            String code = "test_code";
+            KakaoDto.UserInfo mockKakaoUser = createMockKakaoUser(12345L, "라이언");
+            Member existingMember = createMockMember(
+                UUID.randomUUID(),
+                mockKakaoUser.id(),
+                mockKakaoUser.kakaoAccount()
+                    .profile()
+                    .nickname()
+            );
+            TokenDto mockTokenDto = new TokenDto("access", "refresh");
+
+            given(kakaoClientService.getUserInfo(code)).willReturn(mockKakaoUser);
+            given(memberRepository.findByOauthInfoProviderAndOauthInfoProviderId("kakao",
+                mockKakaoUser.id())).willReturn(Optional.of(existingMember));
+            given(jwtUtil.generateToken(any(Authentication.class))).willReturn(mockTokenDto);
+
+            // when
+            TokenDto resultTokenDto = authService.login(code);
+
+            // then
+            assertThat(resultTokenDto).isEqualTo(mockTokenDto);
+            verify(memberRepository, never()).save(any(Member.class));
+            verify(refreshTokenRepository).save(any(RefreshToken.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("로그아웃")
+    class Logout {
+
+        @Test
+        @DisplayName("성공")
+        void logout_Success() {
+            // given
+            UUID memberId = UUID.randomUUID();
+            UserPrincipalDto userPrincipalDto = new UserPrincipalDto(
+                memberId,
+                "testUser",
+                DEFAULT_AVATAR
+            );
+            doNothing().when(refreshTokenRepository)
+                .deleteByMemberId(memberId);
+
+            // when
+            authService.logout(userPrincipalDto);
+
+            // then
+            verify(refreshTokenRepository).deleteByMemberId(memberId);
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 재발급")
+    class Reissue {
+
+        private final String expiredAccessToken = "expired_access";
+        private Authentication authentication;
+        private UserPrincipalDto principal;
+
+        @BeforeEach
+        void setUp() {
+            UUID memberId = UUID.randomUUID();
+            principal = new UserPrincipalDto(
+                memberId,
+                "testUser",
+                DEFAULT_AVATAR
+            );
+            Collection<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("USER"));
+            authentication = new UsernamePasswordAuthenticationToken(
+                principal,
+                null,
+                authorities
+            );
+        }
+
+        @Test
+        @DisplayName("성공")
+        void reissue_Success() {
+            // given
+            String validRefreshToken = "valid_refresh";
+            Member member = createMockMember(
+                principal.id(),
+                12345L,
+                "testUser"
+            );
+            RefreshToken storedToken = RefreshToken.builder().member(member)
+                .refreshToken(validRefreshToken)
+                .build();
+            TokenDto newTokenDto = new TokenDto("new_access", "new_refresh");
+
+            doNothing().when(jwtUtil)
+                .validateToken(validRefreshToken);
+            given(jwtUtil.getAuthentication(expiredAccessToken)).willReturn(authentication);
+            given(refreshTokenRepository.findByMemberId(principal.id()))
+                .willReturn(Optional.of(storedToken));
+            given(jwtUtil.generateToken(authentication)).willReturn(newTokenDto);
+
+            // when
+            TokenDto resultTokenDto = authService.reissue(expiredAccessToken, validRefreshToken);
+
+            // then
+            assertThat(resultTokenDto).isEqualTo(newTokenDto);
+            assertThat(storedToken.getRefreshToken()).isEqualTo(newTokenDto.refreshToken());
+        }
+
+        @Test
+        @DisplayName("실패: 유효하지 않은 리프레시 토큰일 경우 INVALID_REFRESH_TOKEN")
+        void reissue_Fail_WhenRefreshTokenIsInvalid() {
+            // given
+            String invalidRefreshToken = "invalid_refresh";
+            doThrow(new JwtException("Invalid Token")).when(jwtUtil)
+                .validateToken(invalidRefreshToken);
+
+            // when & then
+            assertThatThrownBy(() -> authService.reissue(expiredAccessToken, invalidRefreshToken))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        @Test
+        @DisplayName("실패: DB에 리프레시 토큰이 없을 경우 REFRESH_TOKEN_NOT_FOUND")
+        void reissue_Fail_WhenRefreshTokenNotFound() {
+            // given
+            String unknownRefreshToken = "unknown_refresh";
+            doNothing().when(jwtUtil)
+                .validateToken(unknownRefreshToken);
+            given(jwtUtil.getAuthentication(expiredAccessToken)).willReturn(authentication);
+            given(refreshTokenRepository.findByMemberId(principal.id()))
+                .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> authService.reissue(expiredAccessToken, unknownRefreshToken))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.REFRESH_TOKEN_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패: 요청된 리프레시 토큰과 DB의 토큰이 다를 경우 REFRESH_TOKEN_NOT_EQUALS")
+        void reissue_Fail_WhenRefreshTokenMismatched() {
+            // given
+            String clientRefreshToken = "client_refresh";
+            String storedRefreshTokenValue = "stored_refresh";
+            Member member = createMockMember(
+                principal.id(),
+                12345L,
+                "testUser"
+            );
+            RefreshToken storedToken = RefreshToken.builder().member(member)
+                .refreshToken(storedRefreshTokenValue).build();
+
+            doNothing().when(jwtUtil)
+                .validateToken(clientRefreshToken);
+            given(jwtUtil.getAuthentication(expiredAccessToken)).willReturn(authentication);
+            given(refreshTokenRepository.findByMemberId(principal.id()))
+                .willReturn(Optional.of(storedToken));
+
+            // when & then
+            assertThatThrownBy(() -> authService.reissue(expiredAccessToken, clientRefreshToken))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.REFRESH_TOKEN_NOT_EQUALS);
+        }
+    }
+
+    private KakaoDto.UserInfo createMockKakaoUser(Long id, String nickname) {
+        return new KakaoDto.UserInfo(id, new KakaoDto.UserInfo.KakaoAccount(
+            new KakaoDto.UserInfo.KakaoAccount.Profile(nickname))
+        );
+    }
+
+    private Member createMockMember(
+        UUID id,
+        Long providerId,
+        String name
+    ) {
+        return Member.builder()
+            .id(id)
+            .oauthInfo(OauthInfo.builder()
+                .provider("kakao")
+                .providerId(providerId)
+                .build()
+            ).name(name)
+            .avatar(DEFAULT_AVATAR)
+            .build();
+    }
+}
+


### PR DESCRIPTION
## PR
### 🔍 한 줄 요약
- 로그인 API 테스트 코드 작성 및 부분 수정, 리팩토링을 진행했습니다.

### ✨ 작업 내용
- AuthControllerTest 작성
- AuthServiceTest 작성
- 쿠키, 헤더 누락 예외 추가
- 로그인 인가 코드 요청 방식 @RequestParam -> @RequestBody 변경 (프론트 제안)

### #️⃣ 연관 이슈
- Close #53 