### PR TITLE
✨ 할 일 API 조회 구현

### DIFF
--- a/src/main/java/knu/team1/be/boost/comment/dto/CommentResponseDto.java
+++ b/src/main/java/knu/team1/be/boost/comment/dto/CommentResponseDto.java
@@ -1,0 +1,32 @@
+package knu.team1.be.boost.comment.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import knu.team1.be.boost.comment.entity.Comment;
+
+@Schema(description = "댓글 응답 DTO")
+public record CommentResponseDto(
+
+    @Schema(description = "댓글 ID", example = "e2f8c7d0-4b0a-4b6f-9e4a-1c2d3f4a5b6c")
+    UUID id,
+
+    @Schema(description = "댓글 내용", example = "좋습니다.")
+    String content,
+
+    @Schema(description = "작성자 이름", example = "홍길동")
+    String authorName,
+
+    @Schema(description = "작성일시", example = "2025-10-01T15:30:00")
+    LocalDateTime createdAt
+) {
+
+    public static CommentResponseDto from(Comment comment) {
+        return new CommentResponseDto(
+            comment.getId(),
+            comment.getContent(),
+            comment.getMember().getName(),
+            comment.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/knu/team1/be/boost/comment/entity/Comment.java
+++ b/src/main/java/knu/team1/be/boost/comment/entity/Comment.java
@@ -1,0 +1,43 @@
+package knu.team1.be.boost.comment.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import knu.team1.be.boost.common.entity.SoftDeletableEntity;
+import knu.team1.be.boost.member.entity.Member;
+import knu.team1.be.boost.task.entity.Task;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+
+@Entity
+@Getter
+@Table(name = "comments")
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE tasks SET deleted = true, deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
+public class Comment extends SoftDeletableEntity {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "task_id", nullable = false)
+    private Task task;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "content", nullable = false)
+    private String content;
+}

--- a/src/main/java/knu/team1/be/boost/comment/repository/CommentRepository.java
+++ b/src/main/java/knu/team1/be/boost/comment/repository/CommentRepository.java
@@ -1,0 +1,9 @@
+package knu.team1.be.boost.comment.repository;
+
+import java.util.UUID;
+import knu.team1.be.boost.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, UUID> {
+
+}

--- a/src/main/java/knu/team1/be/boost/comment/repository/CommentRepository.java
+++ b/src/main/java/knu/team1/be/boost/comment/repository/CommentRepository.java
@@ -1,9 +1,12 @@
 package knu.team1.be.boost.comment.repository;
 
+import java.util.List;
 import java.util.UUID;
 import knu.team1.be.boost.comment.entity.Comment;
+import knu.team1.be.boost.task.entity.Task;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, UUID> {
 
+    List<Comment> findAllByTask(Task task);
 }

--- a/src/main/java/knu/team1/be/boost/file/controller/FileApi.java
+++ b/src/main/java/knu/team1/be/boost/file/controller/FileApi.java
@@ -12,8 +12,8 @@ import java.util.UUID;
 import knu.team1.be.boost.auth.dto.UserPrincipalDto;
 import knu.team1.be.boost.file.dto.FileCompleteRequestDto;
 import knu.team1.be.boost.file.dto.FileCompleteResponseDto;
+import knu.team1.be.boost.file.dto.FilePresignedUrlResponseDto;
 import knu.team1.be.boost.file.dto.FileRequestDto;
-import knu.team1.be.boost.file.dto.FileResponseDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -36,7 +36,7 @@ public interface FileApi {
         @ApiResponse(
             responseCode = "201",
             description = "파일 메타 생성 및 업로드 URL 발급 성공",
-            content = @Content(schema = @Schema(implementation = FileResponseDto.class))
+            content = @Content(schema = @Schema(implementation = FilePresignedUrlResponseDto.class))
         ),
         @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content),
         @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
@@ -45,7 +45,7 @@ public interface FileApi {
         @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
     })
     @PostMapping("/upload-url")
-    ResponseEntity<FileResponseDto> uploadFile(
+    ResponseEntity<FilePresignedUrlResponseDto> uploadFile(
         @Valid @RequestBody FileRequestDto request,
         @AuthenticationPrincipal UserPrincipalDto user
     );
@@ -58,7 +58,7 @@ public interface FileApi {
         @ApiResponse(
             responseCode = "200",
             description = "다운로드 URL 발급 성공",
-            content = @Content(schema = @Schema(implementation = FileResponseDto.class))
+            content = @Content(schema = @Schema(implementation = FilePresignedUrlResponseDto.class))
         ),
         @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content),
         @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
@@ -69,7 +69,7 @@ public interface FileApi {
         @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
     })
     @GetMapping("/{fileId}/download-url")
-    ResponseEntity<FileResponseDto> downloadFile(
+    ResponseEntity<FilePresignedUrlResponseDto> downloadFile(
         @PathVariable UUID fileId,
         @AuthenticationPrincipal UserPrincipalDto user
     );

--- a/src/main/java/knu/team1/be/boost/file/controller/FileController.java
+++ b/src/main/java/knu/team1/be/boost/file/controller/FileController.java
@@ -6,8 +6,8 @@ import java.util.UUID;
 import knu.team1.be.boost.auth.dto.UserPrincipalDto;
 import knu.team1.be.boost.file.dto.FileCompleteRequestDto;
 import knu.team1.be.boost.file.dto.FileCompleteResponseDto;
+import knu.team1.be.boost.file.dto.FilePresignedUrlResponseDto;
 import knu.team1.be.boost.file.dto.FileRequestDto;
-import knu.team1.be.boost.file.dto.FileResponseDto;
 import knu.team1.be.boost.file.service.FileService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -23,21 +23,21 @@ public class FileController implements FileApi {
     private final FileService fileService;
 
     @Override
-    public ResponseEntity<FileResponseDto> uploadFile(
+    public ResponseEntity<FilePresignedUrlResponseDto> uploadFile(
         @Valid @RequestBody FileRequestDto request,
         @AuthenticationPrincipal UserPrincipalDto user
     ) {
-        FileResponseDto response = fileService.uploadFile(request, user);
+        FilePresignedUrlResponseDto response = fileService.uploadFile(request, user);
         URI location = URI.create("/api/files/" + response.fileId());
         return ResponseEntity.created(location).body(response);
     }
 
     @Override
-    public ResponseEntity<FileResponseDto> downloadFile(
+    public ResponseEntity<FilePresignedUrlResponseDto> downloadFile(
         @PathVariable UUID fileId,
         @AuthenticationPrincipal UserPrincipalDto user
     ) {
-        FileResponseDto response = fileService.downloadFile(fileId, user);
+        FilePresignedUrlResponseDto response = fileService.downloadFile(fileId, user);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/knu/team1/be/boost/file/dto/FilePresignedUrlResponseDto.java
+++ b/src/main/java/knu/team1/be/boost/file/dto/FilePresignedUrlResponseDto.java
@@ -10,7 +10,7 @@ import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequ
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 
 @Schema(description = "파일 업로드/다운로드 Presigned URL 응답 DTO")
-public record FileResponseDto(
+public record FilePresignedUrlResponseDto(
 
     @Schema(description = "파일 ID (UUID)", example = "2f8f2a2e-4a63-4f3a-8d1b-2a4de6d6f8aa")
     UUID fileId,
@@ -34,13 +34,14 @@ public record FileResponseDto(
     Integer expiresInSeconds
 ) {
 
-    public static FileResponseDto forUpload(File file, PresignedPutObjectRequest presigned,
+    public static FilePresignedUrlResponseDto forUpload(File file,
+        PresignedPutObjectRequest presigned,
         int expiresInSeconds) {
         Map<String, String> headers = new HashMap<>();
         headers.put("Content-Type", file.getMetadata().contentType());
         headers.put("x-amz-server-side-encryption", "AES256");
 
-        return new FileResponseDto(
+        return new FilePresignedUrlResponseDto(
             file.getId(),
             file.getStorageKey().value(),
             presigned.url().toString(),
@@ -50,9 +51,10 @@ public record FileResponseDto(
         );
     }
 
-    public static FileResponseDto forDownload(File file, PresignedGetObjectRequest presigned,
+    public static FilePresignedUrlResponseDto forDownload(File file,
+        PresignedGetObjectRequest presigned,
         int expiresInSeconds) {
-        return new FileResponseDto(
+        return new FilePresignedUrlResponseDto(
             file.getId(),
             file.getStorageKey().value(),
             presigned.url().toString(),

--- a/src/main/java/knu/team1/be/boost/file/dto/FileResponseDto.java
+++ b/src/main/java/knu/team1/be/boost/file/dto/FileResponseDto.java
@@ -1,0 +1,36 @@
+package knu.team1.be.boost.file.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+import knu.team1.be.boost.file.entity.File;
+
+@Schema(description = "파일 응답 DTO")
+public record FileResponseDto(
+
+    @Schema(description = "파일 ID (UUID)", example = "2f8f2a2e-4a63-4f3a-8d1b-2a4de6d6f8aa")
+    UUID id,
+
+    @Schema(description = "파일 이름", example = "document.pdf")
+    String filename,
+
+    @Schema(description = "파일 MIME 타입", example = "application/pdf")
+    String contentType,
+
+    @Schema(description = "파일 크기 (바이트)", example = "102400")
+    Integer sizeBytes,
+
+    @Schema(description = "파일 타입", example = "PDF")
+    String type
+
+) {
+
+    public static FileResponseDto from(File file) {
+        return new FileResponseDto(
+            file.getId(),
+            file.getMetadata().originalFilename(),
+            file.getMetadata().contentType(),
+            file.getMetadata().sizeBytes(),
+            file.getType().name()
+        );
+    }
+}

--- a/src/main/java/knu/team1/be/boost/file/repository/FileRepository.java
+++ b/src/main/java/knu/team1/be/boost/file/repository/FileRepository.java
@@ -1,9 +1,12 @@
 package knu.team1.be.boost.file.repository;
 
+import java.util.List;
 import java.util.UUID;
 import knu.team1.be.boost.file.entity.File;
+import knu.team1.be.boost.task.entity.Task;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FileRepository extends JpaRepository<File, UUID> {
 
+    List<File> findAllByTask(Task task);
 }

--- a/src/main/java/knu/team1/be/boost/file/service/FileService.java
+++ b/src/main/java/knu/team1/be/boost/file/service/FileService.java
@@ -8,8 +8,8 @@ import knu.team1.be.boost.common.exception.ErrorCode;
 import knu.team1.be.boost.common.policy.AccessPolicy;
 import knu.team1.be.boost.file.dto.FileCompleteRequestDto;
 import knu.team1.be.boost.file.dto.FileCompleteResponseDto;
+import knu.team1.be.boost.file.dto.FilePresignedUrlResponseDto;
 import knu.team1.be.boost.file.dto.FileRequestDto;
-import knu.team1.be.boost.file.dto.FileResponseDto;
 import knu.team1.be.boost.file.entity.File;
 import knu.team1.be.boost.file.entity.FileType;
 import knu.team1.be.boost.file.entity.vo.StorageKey;
@@ -50,7 +50,7 @@ public class FileService {
     private DataSize maxUploadSize;
 
     @Transactional
-    public FileResponseDto uploadFile(
+    public FilePresignedUrlResponseDto uploadFile(
         FileRequestDto request,
         UserPrincipalDto user
     ) {
@@ -76,11 +76,11 @@ public class FileService {
 
         log.info("파일 업로드 presigned URL 발급 성공 - fileId={}, filename={}",
             saved.getId(), saved.getMetadata().originalFilename());
-        return FileResponseDto.forUpload(saved, presigned, expireSeconds);
+        return FilePresignedUrlResponseDto.forUpload(saved, presigned, expireSeconds);
     }
 
     @Transactional(readOnly = true)
-    public FileResponseDto downloadFile(
+    public FilePresignedUrlResponseDto downloadFile(
         UUID fileId,
         UserPrincipalDto user
     ) {
@@ -108,7 +108,7 @@ public class FileService {
 
         log.info("파일 다운로드 presigned URL 발급 성공 - fileId={}, filename={}",
             file.getId(), file.getMetadata().originalFilename());
-        return FileResponseDto.forDownload(file, presigned, expireSeconds);
+        return FilePresignedUrlResponseDto.forDownload(file, presigned, expireSeconds);
     }
 
     @Transactional

--- a/src/main/java/knu/team1/be/boost/projectMember/repository/ProjectMemberRepository.java
+++ b/src/main/java/knu/team1/be/boost/projectMember/repository/ProjectMemberRepository.java
@@ -1,8 +1,10 @@
 package knu.team1.be.boost.projectMember.repository;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import knu.team1.be.boost.member.entity.Member;
 import knu.team1.be.boost.projectMember.entity.ProjectMember;
 import knu.team1.be.boost.projectMember.entity.ProjectRole;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -28,4 +30,6 @@ public interface ProjectMemberRepository extends JpaRepository<ProjectMember, UU
     int countByProjectIdAndMemberIdIn(UUID projectId, Collection<UUID> memberIds);
 
     boolean existsByProjectIdAndMemberIdAndRole(UUID projectId, UUID memberId, ProjectRole role);
+
+    List<ProjectMember> findAllByMember(Member member);
 }

--- a/src/main/java/knu/team1/be/boost/task/controller/TaskApi.java
+++ b/src/main/java/knu/team1/be/boost/task/controller/TaskApi.java
@@ -13,6 +13,7 @@ import jakarta.validation.constraints.Min;
 import java.util.UUID;
 import knu.team1.be.boost.auth.dto.UserPrincipalDto;
 import knu.team1.be.boost.task.dto.TaskCreateRequestDto;
+import knu.team1.be.boost.task.dto.TaskDetailResponseDto;
 import knu.team1.be.boost.task.dto.TaskMemberSectionResponseDto;
 import knu.team1.be.boost.task.dto.TaskResponseDto;
 import knu.team1.be.boost.task.dto.TaskSortBy;
@@ -119,6 +120,26 @@ public interface TaskApi {
         @PathVariable UUID projectId,
         @PathVariable UUID taskId,
         @Valid @RequestBody TaskStatusRequestDto request,
+        @AuthenticationPrincipal UserPrincipalDto user
+    );
+
+    @Operation(
+        summary = "특정 프로젝트 할 일 상세 조회",
+        description = "특정 프로젝트에 속한 할 일의 상세 정보를 반환합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공",
+            content = @Content(schema = @Schema(implementation = TaskDetailResponseDto.class))
+        ),
+        @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+        @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content),
+        @ApiResponse(responseCode = "404", description = "존재하지 않는 프로젝트/할 일 ID 포함", content = @Content),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
+    })
+    @GetMapping("/{taskId}/detail")
+    ResponseEntity<TaskDetailResponseDto> getTaskDetail(
+        @PathVariable UUID projectId,
+        @PathVariable UUID taskId,
         @AuthenticationPrincipal UserPrincipalDto user
     );
 

--- a/src/main/java/knu/team1/be/boost/task/controller/TaskApi.java
+++ b/src/main/java/knu/team1/be/boost/task/controller/TaskApi.java
@@ -125,8 +125,8 @@ public interface TaskApi {
     @Operation(
         summary = "프로젝트별 할 일 목록 조회 - 상태 기준 (커서 페이지네이션)",
         description = """
-                특정 상태(TaskStatus)에 해당하는 프로젝트의 할 일 목록을 반환합니다.<br>
-                정렬(sortBy/direction) 가능
+            특정 상태(TaskStatus)에 해당하는 프로젝트의 할 일 목록을 반환합니다.<br>
+            정렬(sortBy/direction) 가능
             """
     )
     @ApiResponses({
@@ -153,8 +153,8 @@ public interface TaskApi {
     @Operation(
         summary = "내 할 일 목록 조회 - 상태 기준 (커서 페이지네이션)",
         description = """
-                로그인한 사용자가 속한 프로젝트들의 특정 상태(TaskStatus)에 해당하는 자신의 할 일 목록을 반환합니다.<br>
-                정렬(sortBy/direction) 가능
+            로그인한 사용자가 속한 프로젝트들의 특정 상태(TaskStatus)에 해당하는 자신의 할 일 목록을 반환합니다.<br>
+            정렬(sortBy/direction) 가능
             """
     )
     @ApiResponses({
@@ -180,9 +180,9 @@ public interface TaskApi {
     @Operation(
         summary = "프로젝트별 할 일 목록 조회 - 특정 팀원 (커서 페이지네이션)",
         description = """
-                특정 팀원의 프로젝트의 할 일 목록을 상태별 섹션으로 반환합니다.<br>
-                정렬은 지원하지 않으며, 기본 정렬만 제공됩니다.(생성일자 오름차순 + REVIEW -> PROGRESS -> TODO 순)<br>
-                DONE 상태는 제공되지 않으며  TODO, PROGRESS, REVIEW로 제공됩니다.
+            특정 팀원의 프로젝트의 할 일 목록을 상태별 섹션으로 반환합니다.<br>
+            정렬은 지원하지 않으며, 기본 정렬만 제공됩니다.(생성일자 오름차순 + REVIEW -> PROGRESS -> TODO 순)<br>
+            DONE 상태는 제공되지 않으며  TODO, PROGRESS, REVIEW로 제공됩니다.
             """
     )
     @ApiResponses({

--- a/src/main/java/knu/team1/be/boost/task/controller/TaskApi.java
+++ b/src/main/java/knu/team1/be/boost/task/controller/TaskApi.java
@@ -150,6 +150,33 @@ public interface TaskApi {
     );
 
     @Operation(
+        summary = "내 할 일 목록 조회 - 상태 기준 (커서 페이지네이션)",
+        description = """
+                로그인한 사용자가 속한 프로젝트들의 특정 상태(TaskStatus)에 해당하는 자신의 할 일 목록을 반환합니다.<br>
+                정렬(sortBy/direction) 가능
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공",
+            content = @Content(schema = @Schema(implementation = TaskStatusSectionDto.class))
+        ),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content),
+        @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+        @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content),
+        @ApiResponse(responseCode = "404", description = "프로젝트/상태 없음", content = @Content),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
+    })
+    @GetMapping("/status/{status}/me")
+    ResponseEntity<TaskStatusSectionDto> listMyTasksByStatus(
+        @PathVariable TaskStatus status,
+        @RequestParam(required = false, defaultValue = "CREATED_AT") TaskSortBy sortBy,
+        @RequestParam(required = false, defaultValue = "ASC") TaskSortDirection direction,
+        @RequestParam(required = false) UUID cursor,
+        @RequestParam(defaultValue = "20") @Min(1) @Max(50) int limit,
+        @AuthenticationPrincipal UserPrincipalDto user
+    );
+
+    @Operation(
         summary = "프로젝트별 할 일 목록 조회 - 특정 팀원 (커서 페이지네이션)",
         description = """
                 특정 팀원의 프로젝트의 할 일 목록을 상태별 섹션으로 반환합니다.<br>

--- a/src/main/java/knu/team1/be/boost/task/controller/TaskApi.java
+++ b/src/main/java/knu/team1/be/boost/task/controller/TaskApi.java
@@ -126,7 +126,6 @@ public interface TaskApi {
         summary = "프로젝트별 할 일 목록 조회 - 상태 기준 (커서 페이지네이션)",
         description = """
                 특정 상태(TaskStatus)에 해당하는 프로젝트의 할 일 목록을 반환합니다.<br>
-                memberId가 있으면 해당 멤버 기준, 없으면 프로젝트 전체 기준 조회<br>
                 정렬(sortBy/direction) 가능
             """
     )

--- a/src/main/java/knu/team1/be/boost/task/controller/TaskApi.java
+++ b/src/main/java/knu/team1/be/boost/task/controller/TaskApi.java
@@ -13,6 +13,7 @@ import jakarta.validation.constraints.Min;
 import java.util.UUID;
 import knu.team1.be.boost.auth.dto.UserPrincipalDto;
 import knu.team1.be.boost.task.dto.TaskCreateRequestDto;
+import knu.team1.be.boost.task.dto.TaskMemberSectionResponseDto;
 import knu.team1.be.boost.task.dto.TaskResponseDto;
 import knu.team1.be.boost.task.dto.TaskSortBy;
 import knu.team1.be.boost.task.dto.TaskSortDirection;
@@ -147,4 +148,31 @@ public interface TaskApi {
         @RequestParam(required = false) UUID cursor,
         @RequestParam(defaultValue = "20") @Min(1) @Max(50) int limit
     );
+
+    @Operation(
+        summary = "프로젝트별 할 일 목록 조회 - 특정 팀원 (커서 페이지네이션)",
+        description = """
+            특정 팀원의 프로젝트의 할 일 목록을 상태별 섹션으로 반환합니다.
+            정렬은 지원하지 않으며, 기본 정렬만 제공됩니다.(생성일자 오름차순)
+            DONE 상태는 제공되지 않으며  TODO, PROGRESS, REVIEW로 제공됩니다.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공",
+            content = @Content(schema = @Schema(implementation = TaskMemberSectionResponseDto.class))
+        ),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content),
+        @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+        @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content),
+        @ApiResponse(responseCode = "404", description = "프로젝트/멤버 없음", content = @Content),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
+    })
+    @GetMapping("/members/{memberId}")
+    ResponseEntity<TaskMemberSectionResponseDto> listTasksByMember(
+        @PathVariable UUID projectId,
+        @PathVariable UUID memberId,
+        @RequestParam(required = false) UUID cursor,
+        @RequestParam(defaultValue = "20") @Min(1) @Max(50) int limit
+    );
+
 }

--- a/src/main/java/knu/team1/be/boost/task/controller/TaskApi.java
+++ b/src/main/java/knu/team1/be/boost/task/controller/TaskApi.java
@@ -35,7 +35,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Tasks", description = "할 일 관련 API")
-@RequestMapping("/api/projects/{projectId}/tasks")
+@RequestMapping("/api")
 @SecurityRequirement(name = "bearerAuth")
 public interface TaskApi {
 
@@ -55,7 +55,7 @@ public interface TaskApi {
         @ApiResponse(responseCode = "404", description = "존재하지 않는 멤버 ID 포함", content = @Content),
         @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
     })
-    @PostMapping
+    @PostMapping("/projects/{projectId}/tasks")
     ResponseEntity<TaskResponseDto> createTask(
         @PathVariable UUID projectId,
         @Valid @RequestBody TaskCreateRequestDto request,
@@ -78,7 +78,7 @@ public interface TaskApi {
         @ApiResponse(responseCode = "404", description = "존재하지 않는 프로젝트/할 일/멤버 ID 포함", content = @Content),
         @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
     })
-    @PutMapping("/{taskId}")
+    @PutMapping("/projects/{projectId}/tasks/{taskId}")
     ResponseEntity<TaskResponseDto> updateTask(
         @PathVariable UUID projectId,
         @PathVariable UUID taskId,
@@ -97,7 +97,7 @@ public interface TaskApi {
         @ApiResponse(responseCode = "404", description = "존재하지 않는 프로젝트/할 일 ID 포함", content = @Content),
         @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
     })
-    @DeleteMapping("/{taskId}")
+    @DeleteMapping("/projects/{projectId}/tasks/{taskId}")
     ResponseEntity<Void> deleteTask(
         @PathVariable UUID projectId,
         @PathVariable UUID taskId,
@@ -115,7 +115,7 @@ public interface TaskApi {
         @ApiResponse(responseCode = "404", description = "존재하지 않는 프로젝트/할 일 ID 포함", content = @Content),
         @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
     })
-    @PatchMapping("/{taskId}")
+    @PatchMapping("/projects/{projectId}/tasks/{taskId}")
     ResponseEntity<TaskResponseDto> changeTaskStatus(
         @PathVariable UUID projectId,
         @PathVariable UUID taskId,
@@ -136,7 +136,7 @@ public interface TaskApi {
         @ApiResponse(responseCode = "404", description = "존재하지 않는 프로젝트/할 일 ID 포함", content = @Content),
         @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
     })
-    @GetMapping("/{taskId}/detail")
+    @GetMapping("/projects/{projectId}/tasks/{taskId}")
     ResponseEntity<TaskDetailResponseDto> getTaskDetail(
         @PathVariable UUID projectId,
         @PathVariable UUID taskId,
@@ -160,10 +160,10 @@ public interface TaskApi {
         @ApiResponse(responseCode = "404", description = "프로젝트/상태 없음", content = @Content),
         @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
     })
-    @GetMapping("/status/{status}")
+    @GetMapping("/projects/{projectId}/tasks")
     ResponseEntity<TaskStatusSectionDto> listTasksByStatus(
         @PathVariable UUID projectId,
-        @PathVariable TaskStatus status,
+        @RequestParam(required = false, defaultValue = "TODO") TaskStatus status,
         @RequestParam(required = false, defaultValue = "CREATED_AT") TaskSortBy sortBy,
         @RequestParam(required = false, defaultValue = "ASC") TaskSortDirection direction,
         @RequestParam(required = false) UUID cursor,
@@ -188,9 +188,9 @@ public interface TaskApi {
         @ApiResponse(responseCode = "404", description = "프로젝트/상태 없음", content = @Content),
         @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
     })
-    @GetMapping("/status/{status}/me")
+    @GetMapping("/me/tasks")
     ResponseEntity<TaskStatusSectionDto> listMyTasksByStatus(
-        @PathVariable TaskStatus status,
+        @RequestParam(required = false, defaultValue = "TODO") TaskStatus status,
         @RequestParam(required = false, defaultValue = "CREATED_AT") TaskSortBy sortBy,
         @RequestParam(required = false, defaultValue = "ASC") TaskSortDirection direction,
         @RequestParam(required = false) UUID cursor,
@@ -216,7 +216,7 @@ public interface TaskApi {
         @ApiResponse(responseCode = "404", description = "프로젝트/멤버 없음", content = @Content),
         @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
     })
-    @GetMapping("/members/{memberId}")
+    @GetMapping("/projects/{projectId}/members/{memberId}/tasks")
     ResponseEntity<TaskMemberSectionResponseDto> listTasksByMember(
         @PathVariable UUID projectId,
         @PathVariable UUID memberId,

--- a/src/main/java/knu/team1/be/boost/task/controller/TaskApi.java
+++ b/src/main/java/knu/team1/be/boost/task/controller/TaskApi.java
@@ -125,7 +125,7 @@ public interface TaskApi {
     @Operation(
         summary = "프로젝트별 할 일 목록 조회 - 상태 기준 (커서 페이지네이션)",
         description = """
-            특정 상태(TaskStatus)에 해당하는 프로젝트의 할 일 목록을 반환합니다.
+            특정 상태(TaskStatus)에 해당하는 프로젝트의 할 일 목록을 반환합니다.<br>
             정렬(sortBy/direction) 가능
             """
     )
@@ -152,8 +152,8 @@ public interface TaskApi {
     @Operation(
         summary = "프로젝트별 할 일 목록 조회 - 특정 팀원 (커서 페이지네이션)",
         description = """
-            특정 팀원의 프로젝트의 할 일 목록을 상태별 섹션으로 반환합니다.
-            정렬은 지원하지 않으며, 기본 정렬만 제공됩니다.(생성일자 오름차순)
+            특정 팀원의 프로젝트의 할 일 목록을 상태별 섹션으로 반환합니다.<br>
+            정렬은 지원하지 않으며, 기본 정렬만 제공됩니다.(생성일자 오름차순 + REVIEW -> PROGRESS -> TODO 순)<br>
             DONE 상태는 제공되지 않으며  TODO, PROGRESS, REVIEW로 제공됩니다.
             """
     )

--- a/src/main/java/knu/team1/be/boost/task/controller/TaskApi.java
+++ b/src/main/java/knu/team1/be/boost/task/controller/TaskApi.java
@@ -146,7 +146,8 @@ public interface TaskApi {
         @RequestParam(required = false, defaultValue = "CREATED_AT") TaskSortBy sortBy,
         @RequestParam(required = false, defaultValue = "ASC") TaskSortDirection direction,
         @RequestParam(required = false) UUID cursor,
-        @RequestParam(defaultValue = "20") @Min(1) @Max(50) int limit
+        @RequestParam(defaultValue = "20") @Min(1) @Max(50) int limit,
+        @AuthenticationPrincipal UserPrincipalDto user
     );
 
     @Operation(
@@ -199,7 +200,8 @@ public interface TaskApi {
         @PathVariable UUID projectId,
         @PathVariable UUID memberId,
         @RequestParam(required = false) UUID cursor,
-        @RequestParam(defaultValue = "20") @Min(1) @Max(50) int limit
+        @RequestParam(defaultValue = "20") @Min(1) @Max(50) int limit,
+        @AuthenticationPrincipal UserPrincipalDto user
     );
 
 }

--- a/src/main/java/knu/team1/be/boost/task/controller/TaskApi.java
+++ b/src/main/java/knu/team1/be/boost/task/controller/TaskApi.java
@@ -125,8 +125,9 @@ public interface TaskApi {
     @Operation(
         summary = "프로젝트별 할 일 목록 조회 - 상태 기준 (커서 페이지네이션)",
         description = """
-            특정 상태(TaskStatus)에 해당하는 프로젝트의 할 일 목록을 반환합니다.<br>
-            정렬(sortBy/direction) 가능
+                특정 상태(TaskStatus)에 해당하는 프로젝트의 할 일 목록을 반환합니다.<br>
+                memberId가 있으면 해당 멤버 기준, 없으면 프로젝트 전체 기준 조회<br>
+                정렬(sortBy/direction) 가능
             """
     )
     @ApiResponses({
@@ -139,7 +140,7 @@ public interface TaskApi {
         @ApiResponse(responseCode = "404", description = "프로젝트/상태 없음", content = @Content),
         @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
     })
-    @GetMapping("/status/{status}/tasks")
+    @GetMapping("/status/{status}")
     ResponseEntity<TaskStatusSectionDto> listTasksByStatus(
         @PathVariable UUID projectId,
         @PathVariable TaskStatus status,
@@ -152,9 +153,9 @@ public interface TaskApi {
     @Operation(
         summary = "프로젝트별 할 일 목록 조회 - 특정 팀원 (커서 페이지네이션)",
         description = """
-            특정 팀원의 프로젝트의 할 일 목록을 상태별 섹션으로 반환합니다.<br>
-            정렬은 지원하지 않으며, 기본 정렬만 제공됩니다.(생성일자 오름차순 + REVIEW -> PROGRESS -> TODO 순)<br>
-            DONE 상태는 제공되지 않으며  TODO, PROGRESS, REVIEW로 제공됩니다.
+                특정 팀원의 프로젝트의 할 일 목록을 상태별 섹션으로 반환합니다.<br>
+                정렬은 지원하지 않으며, 기본 정렬만 제공됩니다.(생성일자 오름차순 + REVIEW -> PROGRESS -> TODO 순)<br>
+                DONE 상태는 제공되지 않으며  TODO, PROGRESS, REVIEW로 제공됩니다.
             """
     )
     @ApiResponses({

--- a/src/main/java/knu/team1/be/boost/task/controller/TaskController.java
+++ b/src/main/java/knu/team1/be/boost/task/controller/TaskController.java
@@ -88,7 +88,7 @@ public class TaskController implements TaskApi {
     @Override
     public ResponseEntity<TaskStatusSectionDto> listTasksByStatus(
         @PathVariable UUID projectId,
-        @PathVariable TaskStatus status,
+        @RequestParam(required = false, defaultValue = "TODO") TaskStatus status,
         @RequestParam(required = false, defaultValue = "CREATED_AT") TaskSortBy sortBy,
         @RequestParam(required = false, defaultValue = "ASC") TaskSortDirection direction,
         @RequestParam(required = false) UUID cursor,
@@ -102,7 +102,7 @@ public class TaskController implements TaskApi {
 
     @Override
     public ResponseEntity<TaskStatusSectionDto> listMyTasksByStatus(
-        @PathVariable TaskStatus status,
+        @RequestParam(required = false, defaultValue = "TODO") TaskStatus status,
         @RequestParam(required = false, defaultValue = "CREATED_AT") TaskSortBy sortBy,
         @RequestParam(required = false, defaultValue = "ASC") TaskSortDirection direction,
         @RequestParam(required = false) UUID cursor,

--- a/src/main/java/knu/team1/be/boost/task/controller/TaskController.java
+++ b/src/main/java/knu/team1/be/boost/task/controller/TaskController.java
@@ -7,6 +7,7 @@ import java.net.URI;
 import java.util.UUID;
 import knu.team1.be.boost.auth.dto.UserPrincipalDto;
 import knu.team1.be.boost.task.dto.TaskCreateRequestDto;
+import knu.team1.be.boost.task.dto.TaskMemberSectionResponseDto;
 import knu.team1.be.boost.task.dto.TaskResponseDto;
 import knu.team1.be.boost.task.dto.TaskSortBy;
 import knu.team1.be.boost.task.dto.TaskSortDirection;
@@ -82,9 +83,21 @@ public class TaskController implements TaskApi {
         @RequestParam(required = false) UUID cursor,
         @RequestParam(defaultValue = "20") @Min(1) @Max(50) int limit
     ) {
-        TaskStatusSectionDto body = taskService.listByStatus(
-            projectId, status, sortBy, direction, cursor, limit
-        );
-        return ResponseEntity.ok(body);
+        TaskStatusSectionDto response =
+            taskService.listByStatus(projectId, status, sortBy, direction, cursor, limit);
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<TaskMemberSectionResponseDto> listTasksByMember(
+        @PathVariable UUID projectId,
+        @PathVariable UUID memberId,
+        @RequestParam(required = false) UUID cursor,
+        @RequestParam(defaultValue = "20") @Min(1) @Max(50) int limit
+    ) {
+        TaskMemberSectionResponseDto response =
+            taskService.listByMember(projectId, memberId, cursor, limit);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/knu/team1/be/boost/task/controller/TaskController.java
+++ b/src/main/java/knu/team1/be/boost/task/controller/TaskController.java
@@ -1,19 +1,26 @@
 package knu.team1.be.boost.task.controller;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import java.net.URI;
 import java.util.UUID;
 import knu.team1.be.boost.auth.dto.UserPrincipalDto;
 import knu.team1.be.boost.task.dto.TaskCreateRequestDto;
 import knu.team1.be.boost.task.dto.TaskResponseDto;
+import knu.team1.be.boost.task.dto.TaskSortBy;
+import knu.team1.be.boost.task.dto.TaskSortDirection;
 import knu.team1.be.boost.task.dto.TaskStatusRequestDto;
+import knu.team1.be.boost.task.dto.TaskStatusSectionDto;
 import knu.team1.be.boost.task.dto.TaskUpdateRequestDto;
+import knu.team1.be.boost.task.entity.TaskStatus;
 import knu.team1.be.boost.task.service.TaskService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -64,5 +71,20 @@ public class TaskController implements TaskApi {
     ) {
         TaskResponseDto response = taskService.changeTaskStatus(projectId, taskId, request, user);
         return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<TaskStatusSectionDto> listTasksByStatus(
+        @PathVariable UUID projectId,
+        @PathVariable TaskStatus status,
+        @RequestParam(required = false, defaultValue = "CREATED_AT") TaskSortBy sortBy,
+        @RequestParam(required = false, defaultValue = "ASC") TaskSortDirection direction,
+        @RequestParam(required = false) UUID cursor,
+        @RequestParam(defaultValue = "20") @Min(1) @Max(50) int limit
+    ) {
+        TaskStatusSectionDto body = taskService.listByStatus(
+            projectId, status, sortBy, direction, cursor, limit
+        );
+        return ResponseEntity.ok(body);
     }
 }

--- a/src/main/java/knu/team1/be/boost/task/controller/TaskController.java
+++ b/src/main/java/knu/team1/be/boost/task/controller/TaskController.java
@@ -7,6 +7,7 @@ import java.net.URI;
 import java.util.UUID;
 import knu.team1.be.boost.auth.dto.UserPrincipalDto;
 import knu.team1.be.boost.task.dto.TaskCreateRequestDto;
+import knu.team1.be.boost.task.dto.TaskDetailResponseDto;
 import knu.team1.be.boost.task.dto.TaskMemberSectionResponseDto;
 import knu.team1.be.boost.task.dto.TaskResponseDto;
 import knu.team1.be.boost.task.dto.TaskSortBy;
@@ -71,6 +72,16 @@ public class TaskController implements TaskApi {
         @AuthenticationPrincipal UserPrincipalDto user
     ) {
         TaskResponseDto response = taskService.changeTaskStatus(projectId, taskId, request, user);
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<TaskDetailResponseDto> getTaskDetail(
+        @PathVariable UUID projectId,
+        @PathVariable UUID taskId,
+        @AuthenticationPrincipal UserPrincipalDto user
+    ) {
+        TaskDetailResponseDto response = taskService.getTaskDetail(projectId, taskId, user);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/knu/team1/be/boost/task/controller/TaskController.java
+++ b/src/main/java/knu/team1/be/boost/task/controller/TaskController.java
@@ -81,10 +81,11 @@ public class TaskController implements TaskApi {
         @RequestParam(required = false, defaultValue = "CREATED_AT") TaskSortBy sortBy,
         @RequestParam(required = false, defaultValue = "ASC") TaskSortDirection direction,
         @RequestParam(required = false) UUID cursor,
-        @RequestParam(defaultValue = "20") @Min(1) @Max(50) int limit
+        @RequestParam(defaultValue = "20") @Min(1) @Max(50) int limit,
+        @AuthenticationPrincipal UserPrincipalDto user
     ) {
         TaskStatusSectionDto response =
-            taskService.listByStatus(projectId, status, sortBy, direction, cursor, limit);
+            taskService.listByStatus(projectId, status, sortBy, direction, cursor, limit, user);
         return ResponseEntity.ok(response);
     }
 
@@ -115,10 +116,11 @@ public class TaskController implements TaskApi {
         @PathVariable UUID projectId,
         @PathVariable UUID memberId,
         @RequestParam(required = false) UUID cursor,
-        @RequestParam(defaultValue = "20") @Min(1) @Max(50) int limit
+        @RequestParam(defaultValue = "20") @Min(1) @Max(50) int limit,
+        @AuthenticationPrincipal UserPrincipalDto user
     ) {
         TaskMemberSectionResponseDto response =
-            taskService.listByMember(projectId, memberId, cursor, limit);
+            taskService.listByMember(projectId, memberId, cursor, limit, user);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/knu/team1/be/boost/task/controller/TaskController.java
+++ b/src/main/java/knu/team1/be/boost/task/controller/TaskController.java
@@ -89,6 +89,28 @@ public class TaskController implements TaskApi {
     }
 
     @Override
+    public ResponseEntity<TaskStatusSectionDto> listMyTasksByStatus(
+        @PathVariable TaskStatus status,
+        @RequestParam(required = false, defaultValue = "CREATED_AT") TaskSortBy sortBy,
+        @RequestParam(required = false, defaultValue = "ASC") TaskSortDirection direction,
+        @RequestParam(required = false) UUID cursor,
+        @RequestParam(defaultValue = "20") @Min(1) @Max(50) int limit,
+        @AuthenticationPrincipal UserPrincipalDto user
+
+    ) {
+        TaskStatusSectionDto result =
+            taskService.listMyTasksByStatus(
+                status,
+                sortBy,
+                direction,
+                cursor,
+                limit,
+                user
+            );
+        return ResponseEntity.ok(result);
+    }
+
+    @Override
     public ResponseEntity<TaskMemberSectionResponseDto> listTasksByMember(
         @PathVariable UUID projectId,
         @PathVariable UUID memberId,

--- a/src/main/java/knu/team1/be/boost/task/dto/CursorInfo.java
+++ b/src/main/java/knu/team1/be/boost/task/dto/CursorInfo.java
@@ -1,0 +1,15 @@
+package knu.team1.be.boost.task.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import knu.team1.be.boost.task.entity.TaskStatus;
+
+public record CursorInfo(
+    TaskStatus taskStatus,
+    LocalDateTime createdAt,
+    LocalDate dueDate,
+    UUID taskId
+) {
+
+}

--- a/src/main/java/knu/team1/be/boost/task/dto/TaskDetailResponseDto.java
+++ b/src/main/java/knu/team1/be/boost/task/dto/TaskDetailResponseDto.java
@@ -1,0 +1,82 @@
+package knu.team1.be.boost.task.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import knu.team1.be.boost.comment.dto.CommentResponseDto;
+import knu.team1.be.boost.comment.entity.Comment;
+import knu.team1.be.boost.file.dto.FileResponseDto;
+import knu.team1.be.boost.file.entity.File;
+import knu.team1.be.boost.member.dto.MemberResponseDto;
+import knu.team1.be.boost.task.entity.Task;
+
+@Schema(description = "할 일(Task) 상세 응답 DTO")
+public record TaskDetailResponseDto(
+
+    @Schema(description = "할 일 ID", example = "3fa85f64-5717-4562-b3fc-2c963f66afa6")
+    UUID id,
+
+    @Schema(description = "할 일 제목", example = "1회차 기술 멘토링 피드백 반영")
+    String title,
+
+    @Schema(description = "할 일 상세 설명", example = "기술 멘토링에서 나온 멘토님의 피드백을 반영한다.")
+    String description,
+
+    @Schema(description = "할 일 상태 (TODO/PROGRESS/REVIEW/DONE)", example = "TODO")
+    String status,
+
+    @Schema(description = "마감일", example = "2025-09-11")
+    LocalDate dueDate,
+
+    @Schema(description = "긴급 여부", example = "true")
+    Boolean urgent,
+
+    @Schema(description = "필요 리뷰어 수", example = "2")
+    Integer requiredReviewerCount,
+
+    @Schema(description = "태그 목록", example = "[\"피드백\", \"멘토링\"]")
+    List<String> tags,
+
+    @Schema(description = "담당자 목록", example = "[{\"id\":\"550e8400-e29b-41d4-a716-446655440000\",\"name\":\"홍길동\"}]")
+    List<MemberResponseDto> assignees,
+
+    @Schema(description = "댓글 목록", example = "[{\"id\":\"e2f8c7d0-4b0a-4b6f-9e4a-1c2d3f4a5b6c\",\"content\":\"좋습니다.\",\"authorName\":\"홍길동\"}]")
+    List<CommentResponseDto> comments,
+
+    @Schema(description = "첨부 파일 목록", example = "[{\"id\":\"2f8f2a2e-4a63-4f3a-8d1b-2a4de6d6f8aa\",\"filename\":\"피드백.pdf\",\"contentType\":\"application/pdf\",\"sizeBytes\":102400,\"type\":\"PDF\"}]")
+    List<FileResponseDto> files,
+
+    @Schema(description = "할 일 생성일", example = "2025-10-01T15:30:00")
+    LocalDateTime createdAt,
+
+    @Schema(description = "할 일 수정일", example = "2025-10-02T10:20:00")
+    LocalDateTime updatedAt
+) {
+
+    public static TaskDetailResponseDto from(Task task, List<Comment> comments, List<File> files) {
+        return new TaskDetailResponseDto(
+            task.getId(),
+            task.getTitle(),
+            task.getDescription(),
+            task.getStatus().name(),
+            task.getDueDate(),
+            task.getUrgent(),
+            task.getRequiredReviewerCount(),
+            task.getTags(),
+            task.getAssignees().stream()
+                .map(MemberResponseDto::from)
+                .collect(Collectors.toList()),
+            comments.stream()
+                .map(CommentResponseDto::from)
+                .collect(Collectors.toList()),
+            files.stream()
+                .map(FileResponseDto::from)
+                .collect(Collectors.toList()),
+            task.getCreatedAt(),
+            task.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/knu/team1/be/boost/task/dto/TaskMemberSectionResponseDto.java
+++ b/src/main/java/knu/team1/be/boost/task/dto/TaskMemberSectionResponseDto.java
@@ -1,0 +1,50 @@
+package knu.team1.be.boost.task.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.UUID;
+import knu.team1.be.boost.member.dto.MemberResponseDto;
+import knu.team1.be.boost.member.entity.Member;
+import knu.team1.be.boost.task.entity.Task;
+
+@Schema(description = "팀원 섹션 응답 DTO")
+public record TaskMemberSectionResponseDto(
+
+    @Schema(description = "팀원 정보")
+    MemberResponseDto member,
+
+    @Schema(description = "Task 목록")
+    List<TaskResponseDto> tasks,
+
+    @Schema(description = "현재 응답에 포함된 Task 개수", example = "20")
+    Integer count,
+
+    @Schema(description = "다음 페이지 호출용 커서", example = "550e8400-e29b-41d4-a716-446655440000")
+    UUID nextCursor,
+
+    @Schema(description = "다음 페이지 존재 여부", example = "true")
+    Boolean hasNext
+) {
+
+    public static TaskMemberSectionResponseDto from(Member member, List<Task> tasks, int limit) {
+        boolean hasNext = tasks.size() > limit;
+        UUID nextCursor = null;
+
+        List<TaskResponseDto> taskResponseDtos = tasks.stream()
+            .limit(limit)
+            .map(TaskResponseDto::from)
+            .toList();
+
+        if (hasNext && !taskResponseDtos.isEmpty()) {
+            nextCursor = taskResponseDtos.getLast().taskId();
+        }
+
+        return new TaskMemberSectionResponseDto(
+            MemberResponseDto.from(member),
+            taskResponseDtos,
+            taskResponseDtos.size(),
+            nextCursor,
+            hasNext
+        );
+    }
+}

--- a/src/main/java/knu/team1/be/boost/task/dto/TaskSortBy.java
+++ b/src/main/java/knu/team1/be/boost/task/dto/TaskSortBy.java
@@ -1,0 +1,11 @@
+package knu.team1.be.boost.task.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "정렬 기준")
+public enum TaskSortBy {
+    @Schema(description = "생성일")
+    CREATED_AT,
+    @Schema(description = "마감일")
+    DUE_DATE
+}

--- a/src/main/java/knu/team1/be/boost/task/dto/TaskSortDirection.java
+++ b/src/main/java/knu/team1/be/boost/task/dto/TaskSortDirection.java
@@ -1,0 +1,11 @@
+package knu.team1.be.boost.task.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "정렬 방향")
+public enum TaskSortDirection {
+    @Schema(description = "오름차순")
+    ASC,
+    @Schema(description = "내림차순")
+    DESC
+}

--- a/src/main/java/knu/team1/be/boost/task/dto/TaskStatusSectionDto.java
+++ b/src/main/java/knu/team1/be/boost/task/dto/TaskStatusSectionDto.java
@@ -1,0 +1,43 @@
+package knu.team1.be.boost.task.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.UUID;
+import knu.team1.be.boost.task.entity.Task;
+
+@Schema(description = "커서 기반 상태 리스트 응답")
+public record TaskStatusSectionDto(
+    @Schema(description = "Task 목록")
+    List<TaskResponseDto> tasks,
+
+    @Schema(description = "현재 응답에 포함된 Task 개수", example = "20")
+    Integer count,
+
+    @Schema(description = "다음 페이지 호출용 커서", example = "550e8400-e29b-41d4-a716-446655440000")
+    UUID nextCursor,
+
+    @Schema(description = "다음 페이지 존재 여부", example = "true")
+    Boolean hasNext
+) {
+
+    public static TaskStatusSectionDto from(List<Task> tasks, int limit) {
+        boolean hasNext = tasks.size() > limit;
+        UUID nextCursor = null;
+
+        List<TaskResponseDto> taskResponseDtos = tasks.stream()
+            .limit(limit)
+            .map(TaskResponseDto::from)
+            .toList();
+
+        if (hasNext && !taskResponseDtos.isEmpty()) {
+            nextCursor = taskResponseDtos.getLast().taskId();
+        }
+
+        return new TaskStatusSectionDto(
+            taskResponseDtos,
+            taskResponseDtos.size(),
+            nextCursor,
+            hasNext
+        );
+    }
+}

--- a/src/main/java/knu/team1/be/boost/task/entity/Task.java
+++ b/src/main/java/knu/team1/be/boost/task/entity/Task.java
@@ -17,7 +17,10 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import knu.team1.be.boost.common.entity.SoftDeletableEntity;
+import knu.team1.be.boost.common.exception.BusinessException;
+import knu.team1.be.boost.common.exception.ErrorCode;
 import knu.team1.be.boost.member.entity.Member;
 import knu.team1.be.boost.project.entity.Project;
 import lombok.AccessLevel;
@@ -85,5 +88,14 @@ public class Task extends SoftDeletableEntity {
 
     public void changeStatus(TaskStatus taskStatus) {
         this.status = taskStatus;
+    }
+
+    public void ensureTaskInProject(UUID projectId) {
+        if (!this.getProject().getId().equals(projectId)) {
+            throw new BusinessException(
+                ErrorCode.TASK_NOT_IN_PROJECT,
+                "projectId: " + projectId + ", taskId: " + this.getId()
+            );
+        }
     }
 }

--- a/src/main/java/knu/team1/be/boost/task/entity/TaskStatus.java
+++ b/src/main/java/knu/team1/be/boost/task/entity/TaskStatus.java
@@ -5,4 +5,13 @@ public enum TaskStatus {
     PROGRESS,
     REVIEW,
     DONE;
+
+    public int getOrder() {
+        return switch (this) {
+            case REVIEW -> 1;
+            case PROGRESS -> 2;
+            case TODO -> 3;
+            case DONE -> 99;
+        };
+    }
 }

--- a/src/main/java/knu/team1/be/boost/task/repository/TaskRepository.java
+++ b/src/main/java/knu/team1/be/boost/task/repository/TaskRepository.java
@@ -27,11 +27,11 @@ public interface TaskRepository extends JpaRepository<Task, UUID> {
               AND (
                   (:cursorCreatedAtKey IS NULL AND :cursorDueDateKey IS NULL)
                   OR (
-                      (:sortBy = 'createdAt' AND :direction = 'ASC' AND (
+                      (:sortBy = 'CREATED_AT' AND :direction = 'ASC' AND (
                           t.createdAt > :cursorCreatedAtKey
                           OR (t.createdAt = :cursorCreatedAtKey AND t.id > :cursorId)
                       ))
-                      OR (:sortBy = 'createdAt' AND :direction = 'DESC' AND (
+                      OR (:sortBy = 'CREATED_AT' AND :direction = 'DESC' AND (
                           t.createdAt < :cursorCreatedAtKey
                           OR (t.createdAt = :cursorCreatedAtKey AND t.id < :cursorId)
                       ))
@@ -39,21 +39,67 @@ public interface TaskRepository extends JpaRepository<Task, UUID> {
                           t.dueDate > :cursorDueDateKey
                           OR (t.dueDate = :cursorDueDateKey AND t.id > :cursorId)
                       ))
-                      OR (:sortBy = 'dueDate' AND :direction = 'DESC' AND (
+                      OR (:sortBy = 'DUE_DATE' AND :direction = 'DESC' AND (
                           t.dueDate < :cursorDueDateKey
                           OR (t.dueDate = :cursorDueDateKey AND t.id < :cursorId)
                       ))
                   )
               )
             ORDER BY
-                CASE WHEN :sortBy = 'createdAt' AND :direction = 'ASC' THEN t.createdAt END ASC,
-                CASE WHEN :sortBy = 'createdAt' AND :direction = 'DESC' THEN t.createdAt END DESC,
-                CASE WHEN :sortBy = 'dueDate' AND :direction = 'ASC' THEN t.dueDate END ASC,
-                CASE WHEN :sortBy = 'dueDate' AND :direction = 'DESC' THEN t.dueDate END DESC,
+                CASE WHEN :sortBy = 'CREATED_AT' AND :direction = 'ASC' THEN t.createdAt END ASC,
+                CASE WHEN :sortBy = 'CREATED_AT' AND :direction = 'DESC' THEN t.createdAt END DESC,
+                CASE WHEN :sortBy = 'DUE_DATE' AND :direction = 'ASC' THEN t.dueDate END ASC,
+                CASE WHEN :sortBy = 'DUE_DATE' AND :direction = 'DESC' THEN t.dueDate END DESC,
                 t.id ASC
         """)
     List<Task> findTasksByStatusWithCursor(
         @Param("project") Project project,
+        @Param("status") TaskStatus status,
+        @Param("cursorCreatedAtKey") LocalDateTime cursorCreatedAtKey,
+        @Param("cursorDueDateKey") LocalDate cursorDueDateKey,
+        @Param("cursorId") UUID cursorId,
+        @Param("sortBy") String sortBy,
+        @Param("direction") String direction,
+        Pageable pageable
+    );
+
+    @Query("""
+            SELECT t
+            FROM Task t
+            WHERE t.project IN :projects
+              AND :member MEMBER OF t.assignees
+              AND t.status = :status
+              AND (
+                  (:cursorCreatedAtKey IS NULL AND :cursorDueDateKey IS NULL)
+                  OR (
+                      (:sortBy = 'CREATED_AT' AND :direction = 'ASC' AND (
+                          t.createdAt > :cursorCreatedAtKey
+                          OR (t.createdAt = :cursorCreatedAtKey AND t.id > :cursorId)
+                      ))
+                      OR (:sortBy = 'CREATED_AT' AND :direction = 'DESC' AND (
+                          t.createdAt < :cursorCreatedAtKey
+                          OR (t.createdAt = :cursorCreatedAtKey AND t.id < :cursorId)
+                      ))
+                      OR (:sortBy = 'DUE_DATE' AND :direction = 'ASC' AND (
+                          t.dueDate > :cursorDueDateKey
+                          OR (t.dueDate = :cursorDueDateKey AND t.id > :cursorId)
+                      ))
+                      OR (:sortBy = 'DUE_DATE' AND :direction = 'DESC' AND (
+                          t.dueDate < :cursorDueDateKey
+                          OR (t.dueDate = :cursorDueDateKey AND t.id < :cursorId)
+                      ))
+                  )
+              )
+            ORDER BY
+                CASE WHEN :sortBy = 'CREATED_AT' AND :direction = 'ASC' THEN t.createdAt END ASC,
+                CASE WHEN :sortBy = 'CREATED_AT' AND :direction = 'DESC' THEN t.createdAt END DESC,
+                CASE WHEN :sortBy = 'DUE_DATE' AND :direction = 'ASC' THEN t.dueDate END ASC,
+                CASE WHEN :sortBy = 'DUE_DATE' AND :direction = 'DESC' THEN t.dueDate END DESC,
+                t.id ASC
+        """)
+    List<Task> findMyTasksByStatusWithCursor(
+        @Param("projects") List<Project> projects,
+        @Param("member") Member member,
         @Param("status") TaskStatus status,
         @Param("cursorCreatedAtKey") LocalDateTime cursorCreatedAtKey,
         @Param("cursorDueDateKey") LocalDate cursorDueDateKey,

--- a/src/main/java/knu/team1/be/boost/task/repository/TaskRepository.java
+++ b/src/main/java/knu/team1/be/boost/task/repository/TaskRepository.java
@@ -24,88 +24,119 @@ public interface TaskRepository extends JpaRepository<Task, UUID> {
             SELECT t FROM Task t
             WHERE t.project = :project
               AND t.status = :status
-              AND (
-                  (:cursorCreatedAtKey IS NULL AND :cursorDueDateKey IS NULL)
-                  OR (
-                      (:sortBy = 'CREATED_AT' AND :direction = 'ASC' AND (
-                          t.createdAt > :cursorCreatedAtKey
-                          OR (t.createdAt = :cursorCreatedAtKey AND t.id > :cursorId)
-                      ))
-                      OR (:sortBy = 'CREATED_AT' AND :direction = 'DESC' AND (
-                          t.createdAt < :cursorCreatedAtKey
-                          OR (t.createdAt = :cursorCreatedAtKey AND t.id < :cursorId)
-                      ))
-                      OR (:sortBy = 'DUE_DATE' AND :direction = 'ASC' AND (
-                          t.dueDate > :cursorDueDateKey
-                          OR (t.dueDate = :cursorDueDateKey AND t.id > :cursorId)
-                      ))
-                      OR (:sortBy = 'DUE_DATE' AND :direction = 'DESC' AND (
-                          t.dueDate < :cursorDueDateKey
-                          OR (t.dueDate = :cursorDueDateKey AND t.id < :cursorId)
-                      ))
-                  )
-              )
-            ORDER BY
-                CASE WHEN :sortBy = 'CREATED_AT' AND :direction = 'ASC' THEN t.createdAt END ASC,
-                CASE WHEN :sortBy = 'CREATED_AT' AND :direction = 'DESC' THEN t.createdAt END DESC,
-                CASE WHEN :sortBy = 'DUE_DATE' AND :direction = 'ASC' THEN t.dueDate END ASC,
-                CASE WHEN :sortBy = 'DUE_DATE' AND :direction = 'DESC' THEN t.dueDate END DESC,
-                t.id ASC
+              AND (:cursorCreatedAtKey IS NULL OR t.createdAt > :cursorCreatedAtKey)
+            ORDER BY t.createdAt ASC, t.id ASC
         """)
-    List<Task> findTasksByStatusWithCursor(
+    List<Task> findByStatusOrderByCreatedAtAsc(
         @Param("project") Project project,
         @Param("status") TaskStatus status,
         @Param("cursorCreatedAtKey") LocalDateTime cursorCreatedAtKey,
-        @Param("cursorDueDateKey") LocalDate cursorDueDateKey,
-        @Param("cursorId") UUID cursorId,
-        @Param("sortBy") String sortBy,
-        @Param("direction") String direction,
         Pageable pageable
     );
 
     @Query("""
-            SELECT t
-            FROM Task t
+            SELECT t FROM Task t
+            WHERE t.project = :project
+              AND t.status = :status
+              AND (:cursorCreatedAtKey IS NULL OR t.createdAt < :cursorCreatedAtKey)
+            ORDER BY t.createdAt DESC, t.id DESC
+        """)
+    List<Task> findByStatusOrderByCreatedAtDesc(
+        @Param("project") Project project,
+        @Param("status") TaskStatus status,
+        @Param("cursorCreatedAtKey") LocalDateTime cursorCreatedAtKey,
+        Pageable pageable
+    );
+
+    @Query("""
+            SELECT t FROM Task t
+            WHERE t.project = :project
+              AND t.status = :status
+              AND (:cursorDueDateKey IS NULL OR t.dueDate > :cursorDueDateKey)
+            ORDER BY t.dueDate ASC, t.id ASC
+        """)
+    List<Task> findByStatusOrderByDueDateAsc(
+        @Param("project") Project project,
+        @Param("status") TaskStatus status,
+        @Param("cursorDueDateKey") LocalDate cursorDueDateKey,
+        Pageable pageable
+    );
+
+    @Query("""
+            SELECT t FROM Task t
+            WHERE t.project = :project
+              AND t.status = :status
+              AND (:cursorDueDateKey IS NULL OR t.dueDate < :cursorDueDateKey)
+            ORDER BY t.dueDate DESC, t.id DESC
+        """)
+    List<Task> findByStatusOrderByDueDateDesc(
+        @Param("project") Project project,
+        @Param("status") TaskStatus status,
+        @Param("cursorDueDateKey") LocalDate cursorDueDateKey,
+        Pageable pageable
+    );
+
+    @Query("""
+            SELECT t FROM Task t
             WHERE t.project IN :projects
               AND :member MEMBER OF t.assignees
               AND t.status = :status
-              AND (
-                  (:cursorCreatedAtKey IS NULL AND :cursorDueDateKey IS NULL)
-                  OR (
-                      (:sortBy = 'CREATED_AT' AND :direction = 'ASC' AND (
-                          t.createdAt > :cursorCreatedAtKey
-                          OR (t.createdAt = :cursorCreatedAtKey AND t.id > :cursorId)
-                      ))
-                      OR (:sortBy = 'CREATED_AT' AND :direction = 'DESC' AND (
-                          t.createdAt < :cursorCreatedAtKey
-                          OR (t.createdAt = :cursorCreatedAtKey AND t.id < :cursorId)
-                      ))
-                      OR (:sortBy = 'DUE_DATE' AND :direction = 'ASC' AND (
-                          t.dueDate > :cursorDueDateKey
-                          OR (t.dueDate = :cursorDueDateKey AND t.id > :cursorId)
-                      ))
-                      OR (:sortBy = 'DUE_DATE' AND :direction = 'DESC' AND (
-                          t.dueDate < :cursorDueDateKey
-                          OR (t.dueDate = :cursorDueDateKey AND t.id < :cursorId)
-                      ))
-                  )
-              )
-            ORDER BY
-                CASE WHEN :sortBy = 'CREATED_AT' AND :direction = 'ASC' THEN t.createdAt END ASC,
-                CASE WHEN :sortBy = 'CREATED_AT' AND :direction = 'DESC' THEN t.createdAt END DESC,
-                CASE WHEN :sortBy = 'DUE_DATE' AND :direction = 'ASC' THEN t.dueDate END ASC,
-                CASE WHEN :sortBy = 'DUE_DATE' AND :direction = 'DESC' THEN t.dueDate END DESC,
-                t.id ASC
+              AND (:cursorCreatedAtKey IS NULL OR t.createdAt > :cursorCreatedAtKey)
+            ORDER BY t.createdAt ASC, t.id ASC
         """)
-    List<Task> findMyTasksByStatusWithCursor(
+    List<Task> findMyTasksOrderByCreatedAtAsc(
         @Param("projects") List<Project> projects,
         @Param("member") Member member,
         @Param("status") TaskStatus status,
         @Param("cursorCreatedAtKey") LocalDateTime cursorCreatedAtKey,
+        Pageable pageable
+    );
+
+    @Query("""
+            SELECT t FROM Task t
+            WHERE t.project IN :projects
+              AND :member MEMBER OF t.assignees
+              AND t.status = :status
+              AND (:cursorCreatedAtKey IS NULL OR t.createdAt < :cursorCreatedAtKey)
+            ORDER BY t.createdAt DESC, t.id DESC
+        """)
+    List<Task> findMyTasksOrderByCreatedAtDesc(
+        @Param("projects") List<Project> projects,
+        @Param("member") Member member,
+        @Param("status") TaskStatus status,
+        @Param("cursorCreatedAtKey") LocalDateTime cursorCreatedAtKey,
+        Pageable pageable
+    );
+
+    @Query("""
+            SELECT t FROM Task t
+            WHERE t.project IN :projects
+              AND :member MEMBER OF t.assignees
+              AND t.status = :status
+              AND (:cursorDueDateKey IS NULL OR t.dueDate > :cursorDueDateKey)
+            ORDER BY t.dueDate ASC, t.id ASC
+        """)
+    List<Task> findMyTasksOrderByDueDateAsc(
+        @Param("projects") List<Project> projects,
+        @Param("member") Member member,
+        @Param("status") TaskStatus status,
         @Param("cursorDueDateKey") LocalDate cursorDueDateKey,
-        @Param("cursorId") UUID cursorId,
-        @Param("sortBy") String sortBy,
-        @Param("direction") String direction,
+        Pageable pageable
+    );
+
+    @Query("""
+            SELECT t FROM Task t
+            WHERE t.project IN :projects
+              AND :member MEMBER OF t.assignees
+              AND t.status = :status
+              AND (:cursorDueDateKey IS NULL OR t.dueDate < :cursorDueDateKey)
+            ORDER BY t.dueDate DESC, t.id DESC
+        """)
+    List<Task> findMyTasksOrderByDueDateDesc(
+        @Param("projects") List<Project> projects,
+        @Param("member") Member member,
+        @Param("status") TaskStatus status,
+        @Param("cursorDueDateKey") LocalDate cursorDueDateKey,
         Pageable pageable
     );
 

--- a/src/main/java/knu/team1/be/boost/task/repository/TaskRepository.java
+++ b/src/main/java/knu/team1/be/boost/task/repository/TaskRepository.java
@@ -1,10 +1,65 @@
 package knu.team1.be.boost.task.repository;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
+import knu.team1.be.boost.project.entity.Project;
 import knu.team1.be.boost.task.entity.Task;
+import knu.team1.be.boost.task.entity.TaskStatus;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TaskRepository extends JpaRepository<Task, UUID> {
 
     boolean existsByIdAndAssigneesId(UUID taskId, UUID memberId);
+
+    Optional<Task> findByIdAndProjectId(UUID taskId, UUID projectId);
+
+    @Query("""
+            SELECT t FROM Task t
+            WHERE t.project = :project
+              AND t.status = :status
+              AND (
+                  (:cursorCreatedAtKey IS NULL AND :cursorDueDateKey IS NULL)
+                  OR (
+                      (:sortBy = 'createdAt' AND :direction = 'ASC' AND (
+                          t.createdAt > :cursorCreatedAtKey
+                          OR (t.createdAt = :cursorCreatedAtKey AND t.id > :cursorId)
+                      ))
+                      OR (:sortBy = 'createdAt' AND :direction = 'DESC' AND (
+                          t.createdAt < :cursorCreatedAtKey
+                          OR (t.createdAt = :cursorCreatedAtKey AND t.id < :cursorId)
+                      ))
+                      OR (:sortBy = 'dueDate' AND :direction = 'ASC' AND (
+                          t.dueDate > :cursorDueDateKey
+                          OR (t.dueDate = :cursorDueDateKey AND t.id > :cursorId)
+                      ))
+                      OR (:sortBy = 'dueDate' AND :direction = 'DESC' AND (
+                          t.dueDate < :cursorDueDateKey
+                          OR (t.dueDate = :cursorDueDateKey AND t.id < :cursorId)
+                      ))
+                  )
+              )
+            ORDER BY
+                CASE WHEN :sortBy = 'createdAt' AND :direction = 'ASC' THEN t.createdAt END ASC,
+                CASE WHEN :sortBy = 'createdAt' AND :direction = 'DESC' THEN t.createdAt END DESC,
+                CASE WHEN :sortBy = 'dueDate' AND :direction = 'ASC' THEN t.dueDate END ASC,
+                CASE WHEN :sortBy = 'dueDate' AND :direction = 'DESC' THEN t.dueDate END DESC,
+                t.id ASC
+        """)
+    List<Task> findTasksByStatusWithCursor(
+        @Param("project") Project project,
+        @Param("status") TaskStatus status,
+        @Param("cursorCreatedAtKey") LocalDateTime cursorCreatedAtKey,
+        @Param("cursorDueDateKey") LocalDate cursorDueDateKey,
+        @Param("cursorId") UUID cursorId,
+        @Param("sortBy") String sortBy,
+        @Param("direction") String direction,
+        Pageable pageable
+    );
+
 }

--- a/src/main/java/knu/team1/be/boost/task/repository/TaskRepository.java
+++ b/src/main/java/knu/team1/be/boost/task/repository/TaskRepository.java
@@ -35,7 +35,7 @@ public interface TaskRepository extends JpaRepository<Task, UUID> {
                           t.createdAt < :cursorCreatedAtKey
                           OR (t.createdAt = :cursorCreatedAtKey AND t.id < :cursorId)
                       ))
-                      OR (:sortBy = 'dueDate' AND :direction = 'ASC' AND (
+                      OR (:sortBy = 'DUE_DATE' AND :direction = 'ASC' AND (
                           t.dueDate > :cursorDueDateKey
                           OR (t.dueDate = :cursorDueDateKey AND t.id > :cursorId)
                       ))

--- a/src/main/java/knu/team1/be/boost/task/repository/TaskRepository.java
+++ b/src/main/java/knu/team1/be/boost/task/repository/TaskRepository.java
@@ -24,13 +24,16 @@ public interface TaskRepository extends JpaRepository<Task, UUID> {
             SELECT t FROM Task t
             WHERE t.project = :project
               AND t.status = :status
-              AND (:cursorCreatedAtKey IS NULL OR t.createdAt > :cursorCreatedAtKey)
+              AND (:cursorCreatedAtKey IS NULL
+                   OR t.createdAt > :cursorCreatedAtKey
+                   OR (t.createdAt = :cursorCreatedAtKey AND t.id > :cursorId))
             ORDER BY t.createdAt ASC, t.id ASC
         """)
     List<Task> findByStatusOrderByCreatedAtAsc(
         @Param("project") Project project,
         @Param("status") TaskStatus status,
         @Param("cursorCreatedAtKey") LocalDateTime cursorCreatedAtKey,
+        @Param("cursorId") UUID cursorId,
         Pageable pageable
     );
 
@@ -38,13 +41,16 @@ public interface TaskRepository extends JpaRepository<Task, UUID> {
             SELECT t FROM Task t
             WHERE t.project = :project
               AND t.status = :status
-              AND (:cursorCreatedAtKey IS NULL OR t.createdAt < :cursorCreatedAtKey)
+              AND (:cursorCreatedAtKey IS NULL
+                   OR t.createdAt < :cursorCreatedAtKey
+                   OR (t.createdAt = :cursorCreatedAtKey AND t.id < :cursorId))
             ORDER BY t.createdAt DESC, t.id DESC
         """)
     List<Task> findByStatusOrderByCreatedAtDesc(
         @Param("project") Project project,
         @Param("status") TaskStatus status,
         @Param("cursorCreatedAtKey") LocalDateTime cursorCreatedAtKey,
+        @Param("cursorId") UUID cursorId,
         Pageable pageable
     );
 
@@ -52,13 +58,16 @@ public interface TaskRepository extends JpaRepository<Task, UUID> {
             SELECT t FROM Task t
             WHERE t.project = :project
               AND t.status = :status
-              AND (:cursorDueDateKey IS NULL OR t.dueDate > :cursorDueDateKey)
+              AND (:cursorDueDateKey IS NULL
+                   OR t.dueDate > :cursorDueDateKey
+                   OR (t.dueDate = :cursorDueDateKey AND t.id > :cursorId))
             ORDER BY t.dueDate ASC, t.id ASC
         """)
     List<Task> findByStatusOrderByDueDateAsc(
         @Param("project") Project project,
         @Param("status") TaskStatus status,
         @Param("cursorDueDateKey") LocalDate cursorDueDateKey,
+        @Param("cursorId") UUID cursorId,
         Pageable pageable
     );
 
@@ -66,13 +75,16 @@ public interface TaskRepository extends JpaRepository<Task, UUID> {
             SELECT t FROM Task t
             WHERE t.project = :project
               AND t.status = :status
-              AND (:cursorDueDateKey IS NULL OR t.dueDate < :cursorDueDateKey)
+              AND (:cursorDueDateKey IS NULL
+                   OR t.dueDate < :cursorDueDateKey
+                   OR (t.dueDate = :cursorDueDateKey AND t.id < :cursorId))
             ORDER BY t.dueDate DESC, t.id DESC
         """)
     List<Task> findByStatusOrderByDueDateDesc(
         @Param("project") Project project,
         @Param("status") TaskStatus status,
         @Param("cursorDueDateKey") LocalDate cursorDueDateKey,
+        @Param("cursorId") UUID cursorId,
         Pageable pageable
     );
 
@@ -81,7 +93,9 @@ public interface TaskRepository extends JpaRepository<Task, UUID> {
             WHERE t.project IN :projects
               AND :member MEMBER OF t.assignees
               AND t.status = :status
-              AND (:cursorCreatedAtKey IS NULL OR t.createdAt > :cursorCreatedAtKey)
+              AND (:cursorCreatedAtKey IS NULL
+                   OR t.createdAt > :cursorCreatedAtKey
+                   OR (t.createdAt = :cursorCreatedAtKey AND t.id > :cursorId))
             ORDER BY t.createdAt ASC, t.id ASC
         """)
     List<Task> findMyTasksOrderByCreatedAtAsc(
@@ -89,6 +103,7 @@ public interface TaskRepository extends JpaRepository<Task, UUID> {
         @Param("member") Member member,
         @Param("status") TaskStatus status,
         @Param("cursorCreatedAtKey") LocalDateTime cursorCreatedAtKey,
+        @Param("cursorId") UUID cursorId,
         Pageable pageable
     );
 
@@ -97,7 +112,9 @@ public interface TaskRepository extends JpaRepository<Task, UUID> {
             WHERE t.project IN :projects
               AND :member MEMBER OF t.assignees
               AND t.status = :status
-              AND (:cursorCreatedAtKey IS NULL OR t.createdAt < :cursorCreatedAtKey)
+              AND (:cursorCreatedAtKey IS NULL
+                   OR t.createdAt < :cursorCreatedAtKey
+                   OR (t.createdAt = :cursorCreatedAtKey AND t.id < :cursorId))
             ORDER BY t.createdAt DESC, t.id DESC
         """)
     List<Task> findMyTasksOrderByCreatedAtDesc(
@@ -105,6 +122,7 @@ public interface TaskRepository extends JpaRepository<Task, UUID> {
         @Param("member") Member member,
         @Param("status") TaskStatus status,
         @Param("cursorCreatedAtKey") LocalDateTime cursorCreatedAtKey,
+        @Param("cursorId") UUID cursorId,
         Pageable pageable
     );
 
@@ -113,7 +131,9 @@ public interface TaskRepository extends JpaRepository<Task, UUID> {
             WHERE t.project IN :projects
               AND :member MEMBER OF t.assignees
               AND t.status = :status
-              AND (:cursorDueDateKey IS NULL OR t.dueDate > :cursorDueDateKey)
+              AND (:cursorDueDateKey IS NULL
+                   OR t.dueDate > :cursorDueDateKey
+                   OR (t.dueDate = :cursorDueDateKey AND t.id > :cursorId))
             ORDER BY t.dueDate ASC, t.id ASC
         """)
     List<Task> findMyTasksOrderByDueDateAsc(
@@ -121,6 +141,7 @@ public interface TaskRepository extends JpaRepository<Task, UUID> {
         @Param("member") Member member,
         @Param("status") TaskStatus status,
         @Param("cursorDueDateKey") LocalDate cursorDueDateKey,
+        @Param("cursorId") UUID cursorId,
         Pageable pageable
     );
 
@@ -129,7 +150,9 @@ public interface TaskRepository extends JpaRepository<Task, UUID> {
             WHERE t.project IN :projects
               AND :member MEMBER OF t.assignees
               AND t.status = :status
-              AND (:cursorDueDateKey IS NULL OR t.dueDate < :cursorDueDateKey)
+              AND (:cursorDueDateKey IS NULL
+                   OR t.dueDate < :cursorDueDateKey
+                   OR (t.dueDate = :cursorDueDateKey AND t.id < :cursorId))
             ORDER BY t.dueDate DESC, t.id DESC
         """)
     List<Task> findMyTasksOrderByDueDateDesc(
@@ -137,6 +160,7 @@ public interface TaskRepository extends JpaRepository<Task, UUID> {
         @Param("member") Member member,
         @Param("status") TaskStatus status,
         @Param("cursorDueDateKey") LocalDate cursorDueDateKey,
+        @Param("cursorId") UUID cursorId,
         Pageable pageable
     );
 

--- a/src/main/java/knu/team1/be/boost/task/repository/TaskRepository.java
+++ b/src/main/java/knu/team1/be/boost/task/repository/TaskRepository.java
@@ -3,7 +3,6 @@ package knu.team1.be.boost.task.repository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import knu.team1.be.boost.member.entity.Member;
 import knu.team1.be.boost.project.entity.Project;
@@ -17,8 +16,6 @@ import org.springframework.data.repository.query.Param;
 public interface TaskRepository extends JpaRepository<Task, UUID> {
 
     boolean existsByIdAndAssigneesId(UUID taskId, UUID memberId);
-
-    Optional<Task> findByIdAndProjectId(UUID taskId, UUID projectId);
 
     @Query("""
             SELECT t FROM Task t

--- a/src/main/java/knu/team1/be/boost/task/service/TaskService.java
+++ b/src/main/java/knu/team1/be/boost/task/service/TaskService.java
@@ -309,10 +309,8 @@ public class TaskService {
     }
 
     private Set<Member> findAssignees(List<UUID> assigneeIds) {
-        Set<Member> assignees = new HashSet<>();
-
         if (assigneeIds == null || assigneeIds.isEmpty()) {
-            return assignees;
+            return Set.of();
         }
 
         List<Member> foundAssignees = memberRepository.findAllById(assigneeIds);
@@ -330,8 +328,7 @@ public class TaskService {
             );
         }
 
-        assignees.addAll(foundAssignees);
-        return assignees;
+        return new HashSet<>(foundAssignees);
     }
 
     private CursorInfo extractCursorInfo(UUID cursorId) {

--- a/src/main/java/knu/team1/be/boost/task/service/TaskService.java
+++ b/src/main/java/knu/team1/be/boost/task/service/TaskService.java
@@ -100,11 +100,7 @@ public class TaskService {
                 ErrorCode.TASK_NOT_FOUND, "taskId: " + taskId
             ));
 
-        if (!task.getProject().getId().equals(project.getId())) {
-            throw new BusinessException(
-                ErrorCode.TASK_NOT_IN_PROJECT, "projectId: " + projectId + ", taskId: " + taskId
-            );
-        }
+        task.ensureTaskInProject(project.getId());
 
         accessPolicy.ensureProjectMember(projectId, user.id());
         accessPolicy.ensureTaskAssignee(taskId, user.id());
@@ -144,11 +140,7 @@ public class TaskService {
                 ErrorCode.TASK_NOT_FOUND, "taskId: " + taskId
             ));
 
-        if (!task.getProject().getId().equals(project.getId())) {
-            throw new BusinessException(
-                ErrorCode.TASK_NOT_IN_PROJECT, "projectId: " + projectId + ", taskId: " + taskId
-            );
-        }
+        task.ensureTaskInProject(project.getId());
 
         accessPolicy.ensureProjectMember(projectId, user.id());
         accessPolicy.ensureTaskAssignee(taskId, user.id());
@@ -173,11 +165,7 @@ public class TaskService {
                 ErrorCode.TASK_NOT_FOUND, "taskId: " + taskId
             ));
 
-        if (!task.getProject().getId().equals(project.getId())) {
-            throw new BusinessException(
-                ErrorCode.TASK_NOT_IN_PROJECT, "projectId: " + projectId + ", taskId: " + taskId
-            );
-        }
+        task.ensureTaskInProject(project.getId());
 
         accessPolicy.ensureProjectMember(projectId, user.id());
         accessPolicy.ensureTaskAssignee(taskId, user.id());
@@ -428,5 +416,4 @@ public class TaskService {
                 throw new IllegalArgumentException("올바르지 않은 sortBy 입니다. " + sortBy);
         }
     }
-
 }

--- a/src/main/java/knu/team1/be/boost/task/service/TaskService.java
+++ b/src/main/java/knu/team1/be/boost/task/service/TaskService.java
@@ -193,12 +193,15 @@ public class TaskService {
         TaskSortBy sortBy,
         TaskSortDirection direction,
         UUID cursorId,
-        int limit
+        int limit,
+        UserPrincipalDto user
     ) {
         Project project = projectRepository.findById(projectId)
             .orElseThrow(() -> new BusinessException(
                 ErrorCode.PROJECT_NOT_FOUND, "projectId: " + projectId
             ));
+
+        accessPolicy.ensureProjectMember(projectId, user.id());
 
         LocalDateTime cursorCreatedAtKey = null;
         LocalDate cursorDueDateKey = null;
@@ -288,12 +291,15 @@ public class TaskService {
         UUID projectId,
         UUID memberId,
         UUID cursorId,
-        int limit
+        int limit,
+        UserPrincipalDto user
     ) {
         Project project = projectRepository.findById(projectId)
             .orElseThrow(() -> new BusinessException(
                 ErrorCode.PROJECT_NOT_FOUND, "projectId: " + projectId)
             );
+
+        accessPolicy.ensureProjectMember(projectId, user.id());
 
         ProjectMember projectMember =
             projectMemberRepository.findByProjectIdAndMemberId(projectId, memberId)

--- a/src/main/java/knu/team1/be/boost/task/service/TaskService.java
+++ b/src/main/java/knu/team1/be/boost/task/service/TaskService.java
@@ -221,14 +221,13 @@ public class TaskService {
         int safeLimit = Math.max(1, Math.min(limit, 50));
         Pageable pageable = PageRequest.of(0, safeLimit + 1);
 
-        List<Task> tasks = taskRepository.findTasksByStatusWithCursor(
+        List<Task> tasks = findTasksByStatusWithCursor(
             project,
             status,
+            sortBy,
+            direction,
             cursorCreatedAtKey,
             cursorDueDateKey,
-            cursorId,
-            sortBy.name(),
-            direction.name(),
             pageable
         );
 
@@ -271,15 +270,14 @@ public class TaskService {
         int safeLimit = Math.max(1, Math.min(limit, 50));
         Pageable pageable = PageRequest.of(0, safeLimit + 1);
 
-        List<Task> tasks = taskRepository.findMyTasksByStatusWithCursor(
+        List<Task> tasks = findMyTasksByStatusWithCursor(
             projects,
             member,
             status,
+            sortBy,
+            direction,
             cursorCreatedAtKey,
             cursorDueDateKey,
-            cursorId,
-            sortBy.name(),
-            direction.name(),
             pageable
         );
 
@@ -373,4 +371,68 @@ public class TaskService {
         assignees.addAll(foundAssignees);
         return assignees;
     }
+
+    private List<Task> findTasksByStatusWithCursor(
+        Project project,
+        TaskStatus status,
+        TaskSortBy sortBy,
+        TaskSortDirection direction,
+        LocalDateTime cursorCreatedAtKey,
+        LocalDate cursorDueDateKey,
+        Pageable pageable
+    ) {
+        switch (sortBy) {
+            case CREATED_AT:
+                if (direction == TaskSortDirection.ASC) {
+                    return taskRepository.findByStatusOrderByCreatedAtAsc(project, status,
+                        cursorCreatedAtKey, pageable);
+                } else {
+                    return taskRepository.findByStatusOrderByCreatedAtDesc(project, status,
+                        cursorCreatedAtKey, pageable);
+                }
+            case DUE_DATE:
+                if (direction == TaskSortDirection.ASC) {
+                    return taskRepository.findByStatusOrderByDueDateAsc(project, status,
+                        cursorDueDateKey, pageable);
+                } else {
+                    return taskRepository.findByStatusOrderByDueDateDesc(project, status,
+                        cursorDueDateKey, pageable);
+                }
+            default:
+                throw new IllegalArgumentException("올바르지 않은 sortBy 입니다. " + sortBy);
+        }
+    }
+
+    private List<Task> findMyTasksByStatusWithCursor(
+        List<Project> projects,
+        Member member,
+        TaskStatus status,
+        TaskSortBy sortBy,
+        TaskSortDirection direction,
+        LocalDateTime cursorCreatedAtKey,
+        LocalDate cursorDueDateKey,
+        Pageable pageable
+    ) {
+        switch (sortBy) {
+            case CREATED_AT:
+                if (direction == TaskSortDirection.ASC) {
+                    return taskRepository.findMyTasksOrderByCreatedAtAsc(projects, member, status,
+                        cursorCreatedAtKey, pageable);
+                } else {
+                    return taskRepository.findMyTasksOrderByCreatedAtDesc(projects, member, status,
+                        cursorCreatedAtKey, pageable);
+                }
+            case DUE_DATE:
+                if (direction == TaskSortDirection.ASC) {
+                    return taskRepository.findMyTasksOrderByDueDateAsc(projects, member, status,
+                        cursorDueDateKey, pageable);
+                } else {
+                    return taskRepository.findMyTasksOrderByDueDateDesc(projects, member, status,
+                        cursorDueDateKey, pageable);
+                }
+            default:
+                throw new IllegalArgumentException("올바르지 않은 sortBy 입니다. " + sortBy);
+        }
+    }
+
 }

--- a/src/main/java/knu/team1/be/boost/task/service/TaskService.java
+++ b/src/main/java/knu/team1/be/boost/task/service/TaskService.java
@@ -66,12 +66,12 @@ public class TaskService {
                 ErrorCode.PROJECT_NOT_FOUND, "projectId: " + projectId
             ));
 
-        accessPolicy.ensureProjectMember(projectId, user.id());
+        accessPolicy.ensureProjectMember(project.getId(), user.id());
 
         List<String> tags = extractTags(request.tags());
         Set<Member> assignees = findAssignees(request.assignees());
 
-        accessPolicy.ensureAssigneesAreProjectMembers(projectId, assignees);
+        accessPolicy.ensureAssigneesAreProjectMembers(project.getId(), assignees);
 
         Task task = Task.builder()
             .project(project)
@@ -109,13 +109,13 @@ public class TaskService {
 
         task.ensureTaskInProject(project.getId());
 
-        accessPolicy.ensureProjectMember(projectId, user.id());
-        accessPolicy.ensureTaskAssignee(taskId, user.id());
+        accessPolicy.ensureProjectMember(project.getId(), user.id());
+        accessPolicy.ensureTaskAssignee(task.getId(), user.id());
 
         List<String> tags = extractTags(request.tags());
         Set<Member> assignees = findAssignees(request.assignees());
 
-        accessPolicy.ensureAssigneesAreProjectMembers(projectId, assignees);
+        accessPolicy.ensureAssigneesAreProjectMembers(project.getId(), assignees);
 
         task.update(
             request.title(),
@@ -149,8 +149,8 @@ public class TaskService {
 
         task.ensureTaskInProject(project.getId());
 
-        accessPolicy.ensureProjectMember(projectId, user.id());
-        accessPolicy.ensureTaskAssignee(taskId, user.id());
+        accessPolicy.ensureProjectMember(project.getId(), user.id());
+        accessPolicy.ensureTaskAssignee(task.getId(), user.id());
 
         taskRepository.delete(task);
     }
@@ -174,8 +174,8 @@ public class TaskService {
 
         task.ensureTaskInProject(project.getId());
 
-        accessPolicy.ensureProjectMember(projectId, user.id());
-        accessPolicy.ensureTaskAssignee(taskId, user.id());
+        accessPolicy.ensureProjectMember(project.getId(), user.id());
+        accessPolicy.ensureTaskAssignee(task.getId(), user.id());
 
         task.changeStatus(request.status());
 
@@ -200,7 +200,7 @@ public class TaskService {
 
         task.ensureTaskInProject(project.getId());
 
-        accessPolicy.ensureProjectMember(projectId, user.id());
+        accessPolicy.ensureProjectMember(project.getId(), user.id());
 
         List<Comment> comments = commentRepository.findAllByTask(task);
         List<File> files = fileRepository.findAllByTask(task);
@@ -223,7 +223,7 @@ public class TaskService {
                 ErrorCode.PROJECT_NOT_FOUND, "projectId: " + projectId
             ));
 
-        accessPolicy.ensureProjectMember(projectId, user.id());
+        accessPolicy.ensureProjectMember(project.getId(), user.id());
 
         CursorInfo cursorInfo = extractCursorInfo(cursorId);
         LocalDateTime cursorCreatedAtKey = cursorInfo.createdAt();
@@ -302,7 +302,7 @@ public class TaskService {
                 ErrorCode.PROJECT_NOT_FOUND, "projectId: " + projectId
             ));
 
-        accessPolicy.ensureProjectMember(projectId, user.id());
+        accessPolicy.ensureProjectMember(project.getId(), user.id());
 
         ProjectMember projectMember =
             projectMemberRepository.findByProjectIdAndMemberId(projectId, memberId)

--- a/src/main/java/knu/team1/be/boost/task/service/TaskService.java
+++ b/src/main/java/knu/team1/be/boost/task/service/TaskService.java
@@ -207,6 +207,7 @@ public class TaskService {
         CursorInfo cursorInfo = extractCursorInfo(cursorId);
         LocalDateTime cursorCreatedAtKey = cursorInfo.createdAt();
         LocalDate cursorDueDateKey = cursorInfo.dueDate();
+        UUID cursorTaskId = cursorInfo.taskId();
 
         int safeLimit = Math.max(1, Math.min(limit, 50));
         Pageable pageable = PageRequest.of(0, safeLimit + 1);
@@ -218,6 +219,7 @@ public class TaskService {
             direction,
             cursorCreatedAtKey,
             cursorDueDateKey,
+            cursorTaskId,
             pageable
         );
 
@@ -246,6 +248,7 @@ public class TaskService {
         CursorInfo cursorInfo = extractCursorInfo(cursorId);
         LocalDateTime cursorCreatedAtKey = cursorInfo.createdAt();
         LocalDate cursorDueDateKey = cursorInfo.dueDate();
+        UUID cursorTaskId = cursorInfo.taskId();
 
         int safeLimit = Math.max(1, Math.min(limit, 50));
         Pageable pageable = PageRequest.of(0, safeLimit + 1);
@@ -258,6 +261,7 @@ public class TaskService {
             direction,
             cursorCreatedAtKey,
             cursorDueDateKey,
+            cursorTaskId,
             pageable
         );
 
@@ -367,24 +371,25 @@ public class TaskService {
         TaskSortDirection direction,
         LocalDateTime cursorCreatedAtKey,
         LocalDate cursorDueDateKey,
+        UUID cursorId,
         Pageable pageable
     ) {
         switch (sortBy) {
             case CREATED_AT:
                 if (direction == TaskSortDirection.ASC) {
                     return taskRepository.findByStatusOrderByCreatedAtAsc(project, status,
-                        cursorCreatedAtKey, pageable);
+                        cursorCreatedAtKey, cursorId, pageable);
                 } else {
                     return taskRepository.findByStatusOrderByCreatedAtDesc(project, status,
-                        cursorCreatedAtKey, pageable);
+                        cursorCreatedAtKey, cursorId, pageable);
                 }
             case DUE_DATE:
                 if (direction == TaskSortDirection.ASC) {
                     return taskRepository.findByStatusOrderByDueDateAsc(project, status,
-                        cursorDueDateKey, pageable);
+                        cursorDueDateKey, cursorId, pageable);
                 } else {
                     return taskRepository.findByStatusOrderByDueDateDesc(project, status,
-                        cursorDueDateKey, pageable);
+                        cursorDueDateKey, cursorId, pageable);
                 }
             default:
                 throw new IllegalArgumentException("올바르지 않은 sortBy 입니다. " + sortBy);
@@ -399,24 +404,25 @@ public class TaskService {
         TaskSortDirection direction,
         LocalDateTime cursorCreatedAtKey,
         LocalDate cursorDueDateKey,
+        UUID cursorId,
         Pageable pageable
     ) {
         switch (sortBy) {
             case CREATED_AT:
                 if (direction == TaskSortDirection.ASC) {
                     return taskRepository.findMyTasksOrderByCreatedAtAsc(projects, member, status,
-                        cursorCreatedAtKey, pageable);
+                        cursorCreatedAtKey, cursorId, pageable);
                 } else {
                     return taskRepository.findMyTasksOrderByCreatedAtDesc(projects, member, status,
-                        cursorCreatedAtKey, pageable);
+                        cursorCreatedAtKey, cursorId, pageable);
                 }
             case DUE_DATE:
                 if (direction == TaskSortDirection.ASC) {
                     return taskRepository.findMyTasksOrderByDueDateAsc(projects, member, status,
-                        cursorDueDateKey, pageable);
+                        cursorDueDateKey, cursorId, pageable);
                 } else {
                     return taskRepository.findMyTasksOrderByDueDateDesc(projects, member, status,
-                        cursorDueDateKey, pageable);
+                        cursorDueDateKey, cursorId, pageable);
                 }
             default:
                 throw new IllegalArgumentException("올바르지 않은 sortBy 입니다. " + sortBy);

--- a/src/test/java/knu/team1/be/boost/file/controller/FileControllerTest.java
+++ b/src/test/java/knu/team1/be/boost/file/controller/FileControllerTest.java
@@ -20,8 +20,8 @@ import knu.team1.be.boost.common.exception.BusinessException;
 import knu.team1.be.boost.common.exception.ErrorCode;
 import knu.team1.be.boost.file.dto.FileCompleteRequestDto;
 import knu.team1.be.boost.file.dto.FileCompleteResponseDto;
+import knu.team1.be.boost.file.dto.FilePresignedUrlResponseDto;
 import knu.team1.be.boost.file.dto.FileRequestDto;
-import knu.team1.be.boost.file.dto.FileResponseDto;
 import knu.team1.be.boost.file.service.FileService;
 import knu.team1.be.boost.security.filter.JwtAuthFilter;
 import org.junit.jupiter.api.DisplayName;
@@ -74,7 +74,7 @@ class FileControllerTest {
             );
 
             UUID fileId = UUID.randomUUID();
-            FileResponseDto response = new FileResponseDto(
+            FilePresignedUrlResponseDto response = new FilePresignedUrlResponseDto(
                 fileId,
                 "file/2025/09/09/" + fileId + ".pdf",
                 "https://boost-s3-bucket-storage.s3.ap-northeast-2.amazonaws.com/...",
@@ -155,7 +155,7 @@ class FileControllerTest {
         void test1() throws Exception {
             // given
             UUID fileId = UUID.randomUUID();
-            FileResponseDto response = new FileResponseDto(
+            FilePresignedUrlResponseDto response = new FilePresignedUrlResponseDto(
                 fileId,
                 "file/2025/09/09/" + fileId + ".pdf",
                 "https://boost-s3-bucket-storage.s3.ap-northeast-2.amazonaws.com/...",

--- a/src/test/java/knu/team1/be/boost/file/service/FileServiceTest.java
+++ b/src/test/java/knu/team1/be/boost/file/service/FileServiceTest.java
@@ -22,8 +22,8 @@ import knu.team1.be.boost.common.exception.ErrorCode;
 import knu.team1.be.boost.common.policy.AccessPolicy;
 import knu.team1.be.boost.file.dto.FileCompleteRequestDto;
 import knu.team1.be.boost.file.dto.FileCompleteResponseDto;
+import knu.team1.be.boost.file.dto.FilePresignedUrlResponseDto;
 import knu.team1.be.boost.file.dto.FileRequestDto;
-import knu.team1.be.boost.file.dto.FileResponseDto;
 import knu.team1.be.boost.file.entity.File;
 import knu.team1.be.boost.file.entity.FileStatus;
 import knu.team1.be.boost.file.entity.FileType;
@@ -80,7 +80,7 @@ class FileServiceTest {
         member = Fixtures.member(userId);
         project = Fixtures.project(projectId);
         task = Fixtures.task(UUID.randomUUID(), project);
-        
+
         fileService = new FileService(
             fileRepository, taskRepository, memberRepository, accessPolicy, presignedUrlFactory
         );
@@ -108,7 +108,7 @@ class FileServiceTest {
                 .willReturn(putReq);
 
             // when
-            FileResponseDto res = fileService.uploadFile(req, user);
+            FilePresignedUrlResponseDto res = fileService.uploadFile(req, user);
 
             // then
             assertThat(res.method()).isEqualTo("PUT");
@@ -162,7 +162,7 @@ class FileServiceTest {
                 .willReturn(getReq);
 
             // when
-            FileResponseDto res = fileService.downloadFile(fileId, user);
+            FilePresignedUrlResponseDto res = fileService.downloadFile(fileId, user);
 
             // then
             assertThat(res.method()).isEqualTo("GET");

--- a/src/test/java/knu/team1/be/boost/task/service/TaskServiceTest.java
+++ b/src/test/java/knu/team1/be/boost/task/service/TaskServiceTest.java
@@ -25,6 +25,7 @@ import knu.team1.be.boost.member.entity.Member;
 import knu.team1.be.boost.member.repository.MemberRepository;
 import knu.team1.be.boost.project.entity.Project;
 import knu.team1.be.boost.project.repository.ProjectRepository;
+import knu.team1.be.boost.projectMember.repository.ProjectMemberRepository;
 import knu.team1.be.boost.task.dto.TaskCreateRequestDto;
 import knu.team1.be.boost.task.dto.TaskResponseDto;
 import knu.team1.be.boost.task.dto.TaskStatusRequestDto;
@@ -49,9 +50,11 @@ class TaskServiceTest {
     @Mock
     MemberRepository memberRepository;
     @Mock
-    AccessPolicy accessPolicy;
-    @Mock
     ProjectRepository projectRepository;
+    @Mock
+    ProjectMemberRepository projectMemberRepository;
+    @Mock
+    AccessPolicy accessPolicy;
 
     TaskService taskService;
 
@@ -68,9 +71,10 @@ class TaskServiceTest {
         projectId = UUID.randomUUID();
         project = Fixtures.project(projectId);
         baseTask = Fixtures.task(UUID.randomUUID(), project);
-        
+
         taskService = new TaskService(
-            taskRepository, memberRepository, projectRepository, accessPolicy
+            taskRepository, memberRepository, projectRepository, projectMemberRepository,
+            accessPolicy
         );
     }
 

--- a/src/test/java/knu/team1/be/boost/task/service/TaskServiceTest.java
+++ b/src/test/java/knu/team1/be/boost/task/service/TaskServiceTest.java
@@ -18,9 +18,11 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import knu.team1.be.boost.auth.dto.UserPrincipalDto;
+import knu.team1.be.boost.comment.repository.CommentRepository;
 import knu.team1.be.boost.common.exception.BusinessException;
 import knu.team1.be.boost.common.exception.ErrorCode;
 import knu.team1.be.boost.common.policy.AccessPolicy;
+import knu.team1.be.boost.file.repository.FileRepository;
 import knu.team1.be.boost.member.entity.Member;
 import knu.team1.be.boost.member.repository.MemberRepository;
 import knu.team1.be.boost.project.entity.Project;
@@ -48,7 +50,11 @@ class TaskServiceTest {
     @Mock
     TaskRepository taskRepository;
     @Mock
+    FileRepository fileRepository;
+    @Mock
     MemberRepository memberRepository;
+    @Mock
+    CommentRepository commentRepository;
     @Mock
     ProjectRepository projectRepository;
     @Mock
@@ -73,7 +79,12 @@ class TaskServiceTest {
         baseTask = Fixtures.task(UUID.randomUUID(), project);
 
         taskService = new TaskService(
-            taskRepository, memberRepository, projectRepository, projectMemberRepository,
+            taskRepository,
+            fileRepository,
+            memberRepository,
+            commentRepository,
+            projectRepository,
+            projectMemberRepository,
             accessPolicy
         );
     }


### PR DESCRIPTION
## PR
### 🔍 한 줄 요약
- 특정 프로젝트 및 회원 기준 할 일 조회, 내 할 일 조회, 할 일 상세 조회 API 구현 및 커서 기반 페이지네이션 적용

### ✨ 작업 내용
- **Task 조회 기능 구현**
  - **특정 프로젝트의 할 일 목록 조회 (`listByStatus`)** – `GET /projects/{projectId}/tasks`  
    - 상태(TaskStatus) 기준 필터링 가능  
    - 정렬(sortBy: CREATED_AT / DUE_DATE, direction: ASC / DESC) 지원  
    - 커서 기반 페이지네이션 적용
  - **특정 프로젝트 내 특정 팀원 기준 할 일 조회 (`listByMember`)** – `GET /projects/{projectId}/members/{memberId}/tasks`  
    - 팀원별 상태 섹션 조회 (REVIEW -> PROGRESS -> TODO 순)  
    - 커서 기반 페이지네이션 적용
  - **로그인한 사용자의 내 할 일 목록 조회 (`listMyTasksByStatus`)** – `GET /me/tasks`  
    - 내가 참여 중인 모든 프로젝트 상태별 섹션 조회 가능  
    - 커서 기반 페이지네이션 적용
  - **할 일 상세 조회 (`getTaskDetail`)** – `GET /projects/{projectId}/tasks/{taskId}`  
    - 프로젝트 존재 여부, 권한 검증  
    - Task, Comment, File 정보 반환

- **커서 기반 페이지네이션 구현**
  - `CursorInfo` 객체를 통해 cursorId를 기반으로 다음 페이지 조회  
  - limit 범위 제한 (1~50) 적용  
  - 정렬 기준에 따라 JPA Repository에서 조건부 조회 수행

- **보안 및 검증**
  - 프로젝트 멤버 여부 확인 (`accessPolicy.ensureProjectMember`)  
  - Task가 해당 프로젝트에 속하는지 검증 (`task.ensureTaskInProject`)  

### #️⃣ 연관 이슈
- Close #55